### PR TITLE
Mount playground endpoint

### DIFF
--- a/src/v0/endpoints/graphql/graphiql.rs
+++ b/src/v0/endpoints/graphql/graphiql.rs
@@ -1,0 +1,14 @@
+use warp::{Filter, Rejection, Reply};
+
+#[allow(dead_code)]
+pub fn filter() -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    let playground = warp::path!("playground" / ..)
+        .map(move || {
+            warp::reply::html(async_graphql::http::playground_source(
+                "http://127.0.0.1:3030/api/v0/graphql",
+                None,
+            ))
+        })
+        .boxed();
+    playground
+}

--- a/src/v0/endpoints/graphql/mod.rs
+++ b/src/v0/endpoints/graphql/mod.rs
@@ -1,5 +1,5 @@
-mod graphiql;
 mod handlers;
+mod playground;
 mod routes;
 mod schema;
 

--- a/src/v0/endpoints/graphql/mod.rs
+++ b/src/v0/endpoints/graphql/mod.rs
@@ -1,3 +1,4 @@
+mod graphiql;
 mod handlers;
 mod routes;
 mod schema;

--- a/src/v0/endpoints/graphql/playground.rs
+++ b/src/v0/endpoints/graphql/playground.rs
@@ -2,13 +2,12 @@ use warp::{Filter, Rejection, Reply};
 
 #[allow(dead_code)]
 pub fn filter() -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    let playground = warp::path!("playground" / ..)
+    warp::path!("playground" / ..)
         .map(move || {
             warp::reply::html(async_graphql::http::playground_source(
                 "http://127.0.0.1:3030/api/v0/graphql",
                 None,
             ))
         })
-        .boxed();
-    playground
+        .boxed()
 }

--- a/src/v0/endpoints/graphql/routes.rs
+++ b/src/v0/endpoints/graphql/routes.rs
@@ -35,7 +35,7 @@ pub async fn filter(
     // expose the playground just when using debugging builds
     #[cfg(debug_assertions)]
     {
-        root.and(crate::v0::endpoints::graphql::graphiql::filter().or(graph_ql))
+        root.and(crate::v0::endpoints::graphql::playground::filter().or(graph_ql))
             .boxed()
     }
 

--- a/src/v0/endpoints/graphql/routes.rs
+++ b/src/v0/endpoints/graphql/routes.rs
@@ -32,5 +32,15 @@ pub async fn filter(
         },
     );
 
-    root.and(graph_ql).boxed()
+    // expose the playground just when using debugging builds
+    #[cfg(debug_assertions)]
+    {
+        root.and(crate::v0::endpoints::graphql::graphiql::filter().or(graph_ql))
+            .boxed()
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        root.and(graph_ql).boxed()
+    }
 }

--- a/src/v0/endpoints/graphql/routes.rs
+++ b/src/v0/endpoints/graphql/routes.rs
@@ -32,15 +32,6 @@ pub async fn filter(
         },
     );
 
-    // expose the playground just when using debugging builds
-    #[cfg(debug_assertions)]
-    {
-        root.and(crate::v0::endpoints::graphql::playground::filter().or(graph_ql))
-            .boxed()
-    }
-
-    #[cfg(not(debug_assertions))]
-    {
-        root.and(graph_ql).boxed()
-    }
+    root.and(crate::v0::endpoints::graphql::playground::filter().or(graph_ql))
+        .boxed()
 }


### PR DESCRIPTION
Playground is the next iteration of the graphiql endpoint. It is just exposed when building a debug binary.
Closes #11 