### PR TITLE
Graph ql errors reporting

### DIFF
--- a/src/v0/endpoints/graphql/handlers/funds.rs
+++ b/src/v0/endpoints/graphql/handlers/funds.rs
@@ -2,7 +2,8 @@ use crate::db::{
     models::funds::Fund, schema::funds::dsl as funds_dsl, schema::funds::dsl::funds as funds_table,
 };
 use crate::v0::endpoints::graphql::schema::QueryRoot;
-use async_graphql::{Context, FieldResult};
+use crate::v0::errors::HandleError;
+use async_graphql::{Context, ErrorExtensions, FieldResult};
 use diesel::query_dsl::filter_dsl::FilterDsl;
 use diesel::{ExpressionMethods, RunQueryDsl};
 
@@ -10,27 +11,25 @@ pub async fn funds<'ctx>(root: &QueryRoot, _ctx: &Context<'_>) -> FieldResult<Ve
     let db_conn = root
         .db_connection_pool
         .get()
-        .map_err(async_graphql::FieldError::from)?;
+        .map_err(|e| HandleError::DatabaseError(e).extend())?;
     tokio::task::spawn_blocking(move || {
         funds_table
             .load::<Fund>(&db_conn)
-            .map_err(async_graphql::FieldError::from)
+            .map_err(|_| HandleError::InternalError("Error retrieving funds".to_string()).extend())
     })
     .await?
-    .map_err(async_graphql::FieldError::from)
 }
 
-pub async fn fund<'ctx>(root: &QueryRoot, id: i32, _ctx: &Context<'_>) -> FieldResult<Fund> {
+pub async fn fund<'ctx>(root: &QueryRoot, fund_id: i32, _ctx: &Context<'_>) -> FieldResult<Fund> {
     let db_conn = root
         .db_connection_pool
         .get()
-        .map_err(async_graphql::FieldError::from)?;
+        .map_err(|e| HandleError::DatabaseError(e).extend())?;
     tokio::task::spawn_blocking(move || {
         funds_table
-            .filter(funds_dsl::id.eq(id))
+            .filter(funds_dsl::id.eq(fund_id))
             .first::<Fund>(&db_conn)
-            .map_err(async_graphql::FieldError::from)
+            .map_err(|_| HandleError::NotFound(format!("id {}", fund_id)).extend())
     })
     .await?
-    .map_err(async_graphql::FieldError::from)
 }

--- a/src/v0/endpoints/graphql/handlers/mod.rs
+++ b/src/v0/endpoints/graphql/handlers/mod.rs
@@ -8,7 +8,10 @@ use async_graphql::Context;
 #[async_graphql::Object]
 impl QueryRoot {
     #[field(desc = "List of proposals")]
-    async fn proposals<'ctx>(&self, _ctx: &Context<'_>) -> Vec<Proposal> {
+    async fn proposals<'ctx>(
+        &self,
+        _ctx: &Context<'_>,
+    ) -> async_graphql::FieldResult<Vec<Proposal>> {
         proposals::proposals(&self, _ctx).await
     }
 


### PR DESCRIPTION
REST endpoints now report with properly response codes as well as a json body explaining the problem with the request.

GraphQL endpoint expand errors with the same information as above.