### PR TITLE
Db types restructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
  "time",
 ]
 
@@ -2026,6 +2027,7 @@ dependencies = [
  "async-graphql-warp",
  "async-trait",
  "base64 0.12.1",
+ "chrono",
  "diesel",
  "dotenv",
  "libsqlite3-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ async-graphql = "1.13.2"
 async-graphql-warp = "1.13.2"
 async-trait = "0.1.33"
 base64 = "0.12.1"
+chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "1.4.4", features = ["sqlite", "r2d2"] }
 dotenv = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/migrations/2020-05-22-112032_initial/up.sql
+++ b/migrations/2020-05-22-112032_initial/up.sql
@@ -6,9 +6,9 @@ create table funds
     fund_goal VARCHAR NOT NULL,
     voting_power_info VARCHAR NOT NULL,
     rewards_info VARCHAR NOT NULL,
-    fund_start_time VARCHAR NOT NULL,
-    fund_end_time VARCHAR NOT NULL,
-    next_fund_start_time VARCHAR NOT NULL
+    fund_start_time BIGINT NOT NULL,
+    fund_end_time BIGINT NOT NULL,
+    next_fund_start_time BIGINT NOT NULL
 );
 
 create table proposals
@@ -40,9 +40,9 @@ create table voteplans
         primary key autoincrement,
     chain_voteplan_id VARCHAR NOT NULL
         unique,
-    chain_vote_start_time VARCHAR NOT NULL,
-    chain_vote_end_time VARCHAR NOT NULL,
-    chain_committee_end_time VARCHAR NOT NULL,
+    chain_vote_start_time BIGINT NOT NULL,
+    chain_vote_end_time BIGINT NOT NULL,
+    chain_committee_end_time BIGINT NOT NULL,
     chain_voteplan_payload VARCHAR NOT NULL,
     fund_id INTEGER NOT NULL
 );

--- a/migrations/2020-05-22-112032_initial/up.sql
+++ b/migrations/2020-05-22-112032_initial/up.sql
@@ -50,8 +50,8 @@ create table voteplans
 create table api_tokens
 (
     token BLOB NOT NULL UNIQUE PRIMARY KEY ,
-    creation_time VARCHAR NOT NULL,
-    expire_time VARCHAR NOT NULL
+    creation_time BIGINT NOT NULL,
+    expire_time BIGINT NOT NULL
 );
 
 

--- a/src/db/models/api_token.rs
+++ b/src/db/models/api_token.rs
@@ -1,22 +1,31 @@
 use crate::db::{schema::api_tokens, DB};
+use crate::utils::datetime::unix_timestamp_to_datetime;
 use crate::v0::api_token::APIToken;
+use chrono::{DateTime, Utc};
 use diesel::Queryable;
 
 #[allow(dead_code)]
 pub struct APITokenData {
     token: APIToken,
-    creation_time: String,
-    expire_time: String,
+    creation_time: DateTime<Utc>,
+    expire_time: DateTime<Utc>,
 }
 
 impl Queryable<api_tokens::SqlType, DB> for APITokenData {
-    type Row = (Vec<u8>, String, String);
+    type Row = (
+        // 0 -> token
+        Vec<u8>,
+        // 1 -> creation_time
+        i64,
+        // 2-> expire_time
+        i64,
+    );
 
     fn build(row: Self::Row) -> Self {
         Self {
             token: APIToken::new(row.0),
-            creation_time: row.1,
-            expire_time: row.2,
+            creation_time: unix_timestamp_to_datetime(row.1),
+            expire_time: unix_timestamp_to_datetime(row.2),
         }
     }
 }

--- a/src/db/models/funds.rs
+++ b/src/db/models/funds.rs
@@ -30,11 +30,11 @@ impl Queryable<funds::SqlType, DB> for Fund {
         // 4 -> rewards_info
         String,
         // 5 -> fund_start_time
-        u64,
+        i64,
         // 6 -> fund_end_time
-        u64,
+        i64,
         // 7 -> next_fund_start_time
-        u64,
+        i64,
     );
 
     fn build(row: Self::Row) -> Self {
@@ -44,9 +44,9 @@ impl Queryable<funds::SqlType, DB> for Fund {
             fund_goal: row.2,
             voting_power_info: row.3,
             rewards_info: row.4,
-            fund_start_time: unix_timestamp_to_datetime(row.5 as i64),
-            fund_end_time: unix_timestamp_to_datetime(row.6 as i64),
-            next_fund_start_time: unix_timestamp_to_datetime(row.7 as i64),
+            fund_start_time: unix_timestamp_to_datetime(row.5),
+            fund_end_time: unix_timestamp_to_datetime(row.6),
+            next_fund_start_time: unix_timestamp_to_datetime(row.7),
             chain_vote_plans: vec![],
         }
     }

--- a/src/db/models/funds.rs
+++ b/src/db/models/funds.rs
@@ -1,4 +1,6 @@
 use crate::db::{models::voteplans::Voteplan, schema::funds, DB};
+use crate::utils::datetime::unix_timestamp_to_datetime;
+use chrono::{DateTime, Utc};
 use diesel::Queryable;
 use serde::{Deserialize, Serialize};
 
@@ -9,9 +11,9 @@ pub struct Fund {
     pub fund_goal: String,
     pub voting_power_info: String,
     pub rewards_info: String,
-    pub fund_start_time: String,
-    pub fund_end_time: String,
-    pub next_fund_start_time: String,
+    pub fund_start_time: DateTime<Utc>,
+    pub fund_end_time: DateTime<Utc>,
+    pub next_fund_start_time: DateTime<Utc>,
     pub chain_vote_plans: Vec<Voteplan>,
 }
 
@@ -28,11 +30,11 @@ impl Queryable<funds::SqlType, DB> for Fund {
         // 4 -> rewards_info
         String,
         // 5 -> fund_start_time
-        String,
+        u64,
         // 6 -> fund_end_time
-        String,
+        u64,
         // 7 -> next_fund_start_time
-        String,
+        u64,
     );
 
     fn build(row: Self::Row) -> Self {
@@ -42,9 +44,9 @@ impl Queryable<funds::SqlType, DB> for Fund {
             fund_goal: row.2,
             voting_power_info: row.3,
             rewards_info: row.4,
-            fund_start_time: row.5,
-            fund_end_time: row.6,
-            next_fund_start_time: row.7,
+            fund_start_time: unix_timestamp_to_datetime(row.5 as i64),
+            fund_end_time: unix_timestamp_to_datetime(row.6 as i64),
+            next_fund_start_time: unix_timestamp_to_datetime(row.7 as i64),
             chain_vote_plans: vec![],
         }
     }

--- a/src/db/models/funds.rs
+++ b/src/db/models/funds.rs
@@ -11,8 +11,11 @@ pub struct Fund {
     pub fund_goal: String,
     pub voting_power_info: String,
     pub rewards_info: String,
+    #[serde(serialize_with = "crate::utils::serde::serialize_datetime_as_rfc3339")]
     pub fund_start_time: DateTime<Utc>,
+    #[serde(serialize_with = "crate::utils::serde::serialize_datetime_as_rfc3339")]
     pub fund_end_time: DateTime<Utc>,
+    #[serde(serialize_with = "crate::utils::serde::serialize_datetime_as_rfc3339")]
     pub next_fund_start_time: DateTime<Utc>,
     pub chain_vote_plans: Vec<Voteplan>,
 }

--- a/src/db/models/proposals.rs
+++ b/src/db/models/proposals.rs
@@ -1,6 +1,8 @@
 use super::vote_options;
 use crate::db::models::vote_options::VoteOptions;
 use crate::db::{views_schema::full_proposals_info, DB};
+use crate::utils::datetime::unix_timestamp_to_datetime;
+use chrono::DateTime;
 use diesel::Queryable;
 use serde::{Deserialize, Serialize};
 
@@ -32,14 +34,14 @@ pub struct Proposal {
     pub proposal_url: String,
     pub proposal_files_url: String,
     pub proposer: Proposer,
-    pub chain_proposal_id: String,
+    pub chain_proposal_id: Vec<u8>,
     pub chain_proposal_index: i64,
     pub chain_vote_options: VoteOptions,
     pub chain_voteplan_id: String,
-    pub chain_voteplan_payload: String,
-    pub chain_vote_start_time: String,
-    pub chain_vote_end_time: String,
-    pub chain_committee_end_time: String,
+    pub chain_voteplan_payload: DateTime<chrono::Utc>,
+    pub chain_vote_start_time: DateTime<chrono::Utc>,
+    pub chain_vote_end_time: DateTime<chrono::Utc>,
+    pub chain_committee_end_time: DateTime<chrono::Utc>,
     pub fund_id: i32,
 }
 
@@ -117,15 +119,14 @@ impl Queryable<full_proposals_info::SqlType, DB> for Proposal {
                 proposer_email: row.12,
                 proposer_url: row.13,
             },
-            // TODO: check, would this be invalid in any case?
-            chain_proposal_id: String::from_utf8(row.14).unwrap(),
+            chain_proposal_id: row.14,
             chain_proposal_index: row.15,
             chain_vote_options: vote_options::VoteOptions::parse_coma_separated_value(&row.16),
             chain_voteplan_id: row.17,
-            chain_vote_start_time: row.18,
-            chain_vote_end_time: row.19,
-            chain_committee_end_time: row.20,
-            chain_voteplan_payload: row.21,
+            chain_vote_start_time: unix_timestamp_to_datetime(row.18 as i64),
+            chain_vote_end_time: unix_timestamp_to_datetime(row.19 as i64),
+            chain_committee_end_time: unix_timestamp_to_datetime(row.20 as i64),
+            chain_voteplan_payload: unix_timestamp_to_datetime(row.21 as i64),
             fund_id: row.22,
         }
     }

--- a/src/db/models/proposals.rs
+++ b/src/db/models/proposals.rs
@@ -38,10 +38,10 @@ pub struct Proposal {
     pub chain_proposal_index: i64,
     pub chain_vote_options: VoteOptions,
     pub chain_voteplan_id: String,
-    pub chain_voteplan_payload: DateTime<chrono::Utc>,
     pub chain_vote_start_time: DateTime<chrono::Utc>,
     pub chain_vote_end_time: DateTime<chrono::Utc>,
     pub chain_committee_end_time: DateTime<chrono::Utc>,
+    pub chain_voteplan_payload: String,
     pub fund_id: i32,
 }
 
@@ -86,11 +86,11 @@ impl Queryable<full_proposals_info::SqlType, DB> for Proposal {
         // 17 -> chain_voteplan_id
         String,
         // 18 -> chain_vote_starttime
-        String,
+        i64,
         // 29 -> chain_vote_endtime
-        String,
+        i64,
         // 20 -> chain_committee_end_time
-        String,
+        i64,
         // 21 -> chain_voteplan_payload
         String,
         // 22 -> fund_id
@@ -123,10 +123,10 @@ impl Queryable<full_proposals_info::SqlType, DB> for Proposal {
             chain_proposal_index: row.15,
             chain_vote_options: vote_options::VoteOptions::parse_coma_separated_value(&row.16),
             chain_voteplan_id: row.17,
-            chain_vote_start_time: unix_timestamp_to_datetime(row.18 as i64),
-            chain_vote_end_time: unix_timestamp_to_datetime(row.19 as i64),
-            chain_committee_end_time: unix_timestamp_to_datetime(row.20 as i64),
-            chain_voteplan_payload: unix_timestamp_to_datetime(row.21 as i64),
+            chain_vote_start_time: unix_timestamp_to_datetime(row.18),
+            chain_vote_end_time: unix_timestamp_to_datetime(row.19),
+            chain_committee_end_time: unix_timestamp_to_datetime(row.20),
+            chain_voteplan_payload: row.21,
             fund_id: row.22,
         }
     }

--- a/src/db/models/proposals.rs
+++ b/src/db/models/proposals.rs
@@ -34,12 +34,16 @@ pub struct Proposal {
     pub proposal_url: String,
     pub proposal_files_url: String,
     pub proposer: Proposer,
+    #[serde(serialize_with = "crate::utils::serde::serialize_bin_as_string")]
     pub chain_proposal_id: Vec<u8>,
     pub chain_proposal_index: i64,
     pub chain_vote_options: VoteOptions,
     pub chain_voteplan_id: String,
+    #[serde(serialize_with = "crate::utils::serde::serialize_datetime_as_rfc3339")]
     pub chain_vote_start_time: DateTime<chrono::Utc>,
+    #[serde(serialize_with = "crate::utils::serde::serialize_datetime_as_rfc3339")]
     pub chain_vote_end_time: DateTime<chrono::Utc>,
+    #[serde(serialize_with = "crate::utils::serde::serialize_datetime_as_rfc3339")]
     pub chain_committee_end_time: DateTime<chrono::Utc>,
     pub chain_voteplan_payload: String,
     pub fund_id: i32,

--- a/src/db/models/voteplans.rs
+++ b/src/db/models/voteplans.rs
@@ -1,13 +1,32 @@
+use crate::db::{schema::voteplans, DB};
+use crate::utils::datetime::unix_timestamp_to_datetime;
+use chrono::{DateTime, Utc};
 use diesel::Queryable;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Queryable)]
+#[derive(Serialize, Deserialize)]
 pub struct Voteplan {
     pub id: i32,
     pub chain_voteplan_id: String,
-    pub chain_vote_start_time: String,
-    pub chain_vote_end_time: String,
-    pub chain_committee_end: String,
+    pub chain_vote_start_time: DateTime<Utc>,
+    pub chain_vote_end_time: DateTime<Utc>,
+    pub chain_committee_end: DateTime<Utc>,
     pub chain_voteplan_payload: String,
     pub fund_id: i32,
+}
+
+impl Queryable<voteplans::SqlType, DB> for Voteplan {
+    type Row = (i32, String, i64, i64, i64, String, i32);
+
+    fn build(row: Self::Row) -> Self {
+        Self {
+            id: row.0,
+            chain_voteplan_id: row.1,
+            chain_vote_start_time: unix_timestamp_to_datetime(row.2),
+            chain_vote_end_time: unix_timestamp_to_datetime(row.3),
+            chain_committee_end: unix_timestamp_to_datetime(row.4),
+            chain_voteplan_payload: "".to_string(),
+            fund_id: row.6,
+        }
+    }
 }

--- a/src/db/models/voteplans.rs
+++ b/src/db/models/voteplans.rs
@@ -16,7 +16,22 @@ pub struct Voteplan {
 }
 
 impl Queryable<voteplans::SqlType, DB> for Voteplan {
-    type Row = (i32, String, i64, i64, i64, String, i32);
+    type Row = (
+        // 0 -> id
+        i32,
+        // 1 > chain_voteplan_id
+        String,
+        // 2 -> chain_vote_start_time
+        i64,
+        // 3 -> chain_vote_end_time
+        i64,
+        // 4 -> chain_committee_end
+        i64,
+        // 5 -> chain_voteplan_payload
+        String,
+        // 6 -> fund_id
+        i32,
+    );
 
     fn build(row: Self::Row) -> Self {
         Self {

--- a/src/db/models/voteplans.rs
+++ b/src/db/models/voteplans.rs
@@ -8,8 +8,11 @@ use serde::{Deserialize, Serialize};
 pub struct Voteplan {
     pub id: i32,
     pub chain_voteplan_id: String,
+    #[serde(serialize_with = "crate::utils::serde::serialize_datetime_as_rfc3339")]
     pub chain_vote_start_time: DateTime<Utc>,
+    #[serde(serialize_with = "crate::utils::serde::serialize_datetime_as_rfc3339")]
     pub chain_vote_end_time: DateTime<Utc>,
+    #[serde(serialize_with = "crate::utils::serde::serialize_datetime_as_rfc3339")]
     pub chain_committee_end: DateTime<Utc>,
     pub chain_voteplan_payload: String,
     pub fund_id: i32,

--- a/src/db/models/voteplans.rs
+++ b/src/db/models/voteplans.rs
@@ -40,7 +40,7 @@ impl Queryable<voteplans::SqlType, DB> for Voteplan {
             chain_vote_start_time: unix_timestamp_to_datetime(row.2),
             chain_vote_end_time: unix_timestamp_to_datetime(row.3),
             chain_committee_end: unix_timestamp_to_datetime(row.4),
-            chain_voteplan_payload: "".to_string(),
+            chain_voteplan_payload: row.5,
             fund_id: row.6,
         }
     }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,8 +1,8 @@
 table! {
     api_tokens (token) {
         token -> Binary,
-        creation_time -> Text,
-        expire_time -> Text,
+        creation_time -> BigInt,
+        expire_time -> BigInt,
     }
 }
 
@@ -54,4 +54,9 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(api_tokens, funds, proposals, voteplans,);
+allow_tables_to_appear_in_same_query!(
+    api_tokens,
+    funds,
+    proposals,
+    voteplans,
+);

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -54,9 +54,4 @@ table! {
     }
 }
 
-allow_tables_to_appear_in_same_query!(
-    api_tokens,
-    funds,
-    proposals,
-    voteplans,
-);
+allow_tables_to_appear_in_same_query!(api_tokens, funds, proposals, voteplans,);

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -13,9 +13,9 @@ table! {
         fund_goal -> Text,
         voting_power_info -> Text,
         rewards_info -> Text,
-        fund_start_time -> Text,
-        fund_end_time -> Text,
-        next_fund_start_time -> Text,
+        fund_start_time -> BigInt,
+        fund_end_time -> BigInt,
+        next_fund_start_time -> BigInt,
     }
 }
 
@@ -46,12 +46,17 @@ table! {
     voteplans (id) {
         id -> Integer,
         chain_voteplan_id -> Text,
-        chain_vote_start_time -> Text,
-        chain_vote_end_time -> Text,
-        chain_committee_end_time -> Text,
+        chain_vote_start_time -> BigInt,
+        chain_vote_end_time -> BigInt,
+        chain_committee_end_time -> BigInt,
         chain_voteplan_payload -> Text,
         fund_id -> Integer,
     }
 }
 
-allow_tables_to_appear_in_same_query!(api_tokens, funds, proposals, voteplans,);
+allow_tables_to_appear_in_same_query!(
+    api_tokens,
+    funds,
+    proposals,
+    voteplans,
+);

--- a/src/db/views_schema.rs
+++ b/src/db/views_schema.rs
@@ -20,9 +20,9 @@ table! {
         chain_proposal_index -> BigInt,
         chain_vote_options -> Text,
         chain_voteplan_id -> Text,
-        chain_vote_start_time -> Text,
-        chain_vote_end_time -> Text,
-        chain_committee_end_time -> Text,
+        chain_vote_start_time -> BigInt,
+        chain_vote_end_time -> BigInt,
+        chain_committee_end_time -> BigInt,
         chain_voteplan_payload -> Text,
         fund_id -> Integer,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ extern crate structopt;
 pub mod db;
 pub mod server;
 pub mod server_settings;
+pub mod utils;
 pub mod v0;
 
 use crate::server_settings::ServiceSettings;

--- a/src/utils/datetime.rs
+++ b/src/utils/datetime.rs
@@ -1,0 +1,5 @@
+use chrono::{DateTime, NaiveDateTime, Utc};
+
+pub fn unix_timestamp_to_datetime(timestamp: i64) -> DateTime<Utc> {
+    DateTime::from_utc(NaiveDateTime::from_timestamp(timestamp, 0), Utc)
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod datetime;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod datetime;
+pub mod serde;

--- a/src/utils/serde.rs
+++ b/src/utils/serde.rs
@@ -9,8 +9,8 @@ pub fn serialize_datetime_as_rfc3339<S: Serializer>(
 }
 
 pub fn serialize_bin_as_string<S: Serializer>(
-    data: &Vec<u8>,
+    data: &[u8],
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    serializer.serialize_str(&String::from_utf8(data.clone()).unwrap())
+    serializer.serialize_str(&String::from_utf8(data.to_vec()).unwrap())
 }

--- a/src/utils/serde.rs
+++ b/src/utils/serde.rs
@@ -1,0 +1,16 @@
+use chrono::{DateTime, Utc};
+use serde::Serializer;
+
+pub fn serialize_datetime_as_rfc3339<S: Serializer>(
+    datetime: &DateTime<Utc>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&datetime.to_rfc3339())
+}
+
+pub fn serialize_bin_as_string<S: Serializer>(
+    data: &Vec<u8>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&String::from_utf8(data.clone()).unwrap())
+}

--- a/src/v0/endpoints/graphql/schema/funds.rs
+++ b/src/v0/endpoints/graphql/schema/funds.rs
@@ -28,16 +28,16 @@ impl Fund {
         &self.rewards_info
     }
 
-    pub async fn fund_start_time(&self) -> &str {
-        &self.fund_start_time
+    pub async fn fund_start_time(&self) -> String {
+        self.fund_start_time.to_rfc3339()
     }
 
-    pub async fn fund_end_time(&self) -> &str {
-        &self.fund_end_time
+    pub async fn fund_end_time(&self) -> String {
+        self.fund_end_time.to_rfc3339()
     }
 
-    pub async fn next_fund_start_time(&self) -> &str {
-        &self.next_fund_start_time
+    pub async fn next_fund_start_time(&self) -> String {
+        self.next_fund_start_time.to_rfc3339()
     }
 
     pub async fn chain_vote_plans(

--- a/src/v0/endpoints/graphql/schema/proposals.rs
+++ b/src/v0/endpoints/graphql/schema/proposals.rs
@@ -77,8 +77,8 @@ impl Proposal {
         &self.proposer
     }
 
-    pub async fn chain_proposal_id(&self) -> &str {
-        &self.chain_proposal_id
+    pub async fn chain_proposal_id(&self) -> String {
+        String::from_utf8(self.chain_proposal_id.clone()).unwrap()
     }
 
     pub async fn chain_voteplan_id(&self) -> &str {
@@ -89,16 +89,16 @@ impl Proposal {
         self.chain_proposal_index
     }
 
-    pub async fn chain_vote_start_time(&self) -> &str {
-        &self.chain_vote_start_time
+    pub async fn chain_vote_start_time(&self) -> String {
+        self.chain_vote_start_time.to_rfc3339()
     }
 
-    pub async fn chain_vote_end_time(&self) -> &str {
-        &self.chain_vote_end_time
+    pub async fn chain_vote_end_time(&self) -> String {
+        self.chain_vote_end_time.to_rfc3339()
     }
 
-    pub async fn chain_committee_end_time(&self) -> &str {
-        &self.chain_committee_end_time
+    pub async fn chain_committee_end_time(&self) -> String {
+        self.chain_committee_end_time.to_rfc3339()
     }
 
     pub async fn chain_vote_options(&self) -> VoteOptions {

--- a/src/v0/endpoints/graphql/schema/voteplans.rs
+++ b/src/v0/endpoints/graphql/schema/voteplans.rs
@@ -10,16 +10,16 @@ impl Voteplan {
         &self.chain_voteplan_id
     }
 
-    pub async fn chain_vote_start_time(&self) -> &str {
-        &self.chain_vote_start_time
+    pub async fn chain_vote_start_time(&self) -> String {
+        self.chain_vote_start_time.to_rfc3339()
     }
 
-    pub async fn chain_vote_end_time(&self) -> &str {
-        &self.chain_vote_end_time
+    pub async fn chain_vote_end_time(&self) -> String {
+        self.chain_vote_end_time.to_rfc3339()
     }
 
-    pub async fn chain_committee_end(&self) -> &str {
-        &self.chain_committee_end
+    pub async fn chain_committee_end(&self) -> String {
+        self.chain_committee_end.to_rfc3339()
     }
 
     pub async fn chain_voteplan_payload(&self) -> &str {


### PR DESCRIPTION
Adapted some of the remaining types:

- DB store datetime objects as unix tiemstamps. Endpoint reporting are `rfc3339` standard strings.
- Some of the ids are now blobs and reported as bytes encoded in a utf8 string .