### PR TITLE
Implemented application exit error codes

### DIFF
--- a/vit-servicing-station-lib/src/server/exit_codes.rs
+++ b/vit-servicing-station-lib/src/server/exit_codes.rs
@@ -1,0 +1,22 @@
+#[derive(PartialEq, Eq, Debug)]
+pub enum ApplicationExitCode {
+    WriteSettingsError = 10,
+    LoadSettingsError,
+    DBConnectionError,
+    LoadBlock0Error,
+}
+
+impl ApplicationExitCode {
+    // TODO: this method can be generalize once std::num new features is stabilized.
+    // https://doc.rust-lang.org/0.12.0/std/num/trait.Num.html
+    // https://doc.rust-lang.org/0.12.0/std/num/trait.FromPrimitive.html
+    pub fn from_i32(n: i32) -> Option<Self> {
+        match n {
+            10 => Some(Self::WriteSettingsError),
+            11 => Some(Self::LoadSettingsError),
+            12 => Some(Self::DBConnectionError),
+            13 => Some(Self::LoadBlock0Error),
+            _ => None,
+        }
+    }
+}

--- a/vit-servicing-station-lib/src/server/exit_codes.rs
+++ b/vit-servicing-station-lib/src/server/exit_codes.rs
@@ -20,3 +20,9 @@ impl ApplicationExitCode {
         }
     }
 }
+
+impl Into<i32> for ApplicationExitCode {
+    fn into(self) -> i32 {
+        self as i32
+    }
+}

--- a/vit-servicing-station-lib/src/server/mod.rs
+++ b/vit-servicing-station-lib/src/server/mod.rs
@@ -1,4 +1,5 @@
 pub mod bootstrapping;
+pub mod exit_codes;
 pub mod settings;
 
 pub use bootstrapping::start_server;

--- a/vit-servicing-station-lib/src/server/settings/config.rs
+++ b/vit-servicing-station-lib/src/server/settings/config.rs
@@ -175,19 +175,19 @@ impl Default for AllowedOrigins {
     }
 }
 
-pub fn load_settings_from_file(file_path: &str) -> Result<ServiceSettings, serde_json::Error> {
-    let f = fs::File::open(file_path)
-        .unwrap_or_else(|e| panic!("Error reading file {}: {}", file_path, e));
+pub fn load_settings_from_file(file_path: &str) -> Result<ServiceSettings, impl std::error::Error> {
+    let f = fs::File::open(file_path)?;
     serde_json::from_reader(&f)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e.to_string()))
 }
 
 pub fn dump_settings_to_file(
     file_path: &str,
     settings: &ServiceSettings,
-) -> Result<(), serde_json::Error> {
-    let f = fs::File::create(file_path)
-        .unwrap_or_else(|e| panic!("Error opening file {}: {}", file_path, e));
+) -> Result<(), impl std::error::Error> {
+    let f = fs::File::create(file_path)?;
     serde_json::to_writer_pretty(&f, settings)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
 }
 
 #[cfg(test)]

--- a/vit-servicing-station-server/src/main.rs
+++ b/vit-servicing-station-server/src/main.rs
@@ -13,7 +13,7 @@ async fn main() {
     if let Some(settings_file) = &settings.out_settings_file {
         server_settings::dump_settings_to_file(settings_file, &settings).unwrap_or_else(|e| {
             println!("Error writing settings to file {}: {}", settings_file, e);
-            std::process::exit(ApplicationExitCode::WriteSettingsError as i32)
+            std::process::exit(ApplicationExitCode::WriteSettingsError.into())
         });
         return;
     }
@@ -22,20 +22,20 @@ async fn main() {
     if let Some(settings_file) = &settings.in_settings_file {
         settings = server_settings::load_settings_from_file(settings_file).unwrap_or_else(|e| {
             println!("Error loading settings from file {}, {}", settings_file, e);
-            std::process::exit(ApplicationExitCode::LoadSettingsError as i32)
+            std::process::exit(ApplicationExitCode::LoadSettingsError.into())
         });
     };
 
     // load db pool
     let db_pool = db::load_db_connection_pool(&settings.db_url).unwrap_or_else(|e| {
         println!("Error connecting to database: {}", e);
-        std::process::exit(ApplicationExitCode::DBConnectionError as i32)
+        std::process::exit(ApplicationExitCode::DBConnectionError.into())
     });
 
     // load block0
     let block0 = std::fs::read(&settings.block0_path).unwrap_or_else(|e| {
         println!("Error loading block0 from {}: {}", &settings.block0_path, e,);
-        std::process::exit(ApplicationExitCode::LoadBlock0Error as i32)
+        std::process::exit(ApplicationExitCode::LoadBlock0Error.into())
     });
 
     let context = v0::context::new_shared_context(db_pool, block0);

--- a/vit-servicing-station-server/src/main.rs
+++ b/vit-servicing-station-server/src/main.rs
@@ -1,7 +1,8 @@
 use structopt::StructOpt;
 
 use vit_servicing_station_lib::{
-    db, server, server::settings as server_settings, server::settings::ServiceSettings, v0,
+    db, server, server::exit_codes::ApplicationExitCode, server::settings as server_settings,
+    server::settings::ServiceSettings, v0,
 };
 
 #[tokio::main]
@@ -12,7 +13,7 @@ async fn main() {
     if let Some(settings_file) = &settings.out_settings_file {
         server_settings::dump_settings_to_file(settings_file, &settings).unwrap_or_else(|e| {
             println!("Error writing settings to file {}: {}", settings_file, e);
-            std::process::exit(1)
+            std::process::exit(ApplicationExitCode::WriteSettingsError as i32)
         });
         return;
     }
@@ -21,20 +22,20 @@ async fn main() {
     if let Some(settings_file) = &settings.in_settings_file {
         settings = server_settings::load_settings_from_file(settings_file).unwrap_or_else(|e| {
             println!("Error loading settings from file {}, {}", settings_file, e);
-            std::process::exit(1)
+            std::process::exit(ApplicationExitCode::LoadSettingsError as i32)
         });
     };
 
     // load db pool
     let db_pool = db::load_db_connection_pool(&settings.db_url).unwrap_or_else(|e| {
         println!("Error connecting to database: {}", e);
-        std::process::exit(1)
+        std::process::exit(ApplicationExitCode::DBConnectionError as i32)
     });
 
     // load block0
     let block0 = std::fs::read(&settings.block0_path).unwrap_or_else(|e| {
         println!("Error loading block0 from {}: {}", &settings.block0_path, e,);
-        std::process::exit(1)
+        std::process::exit(ApplicationExitCode::LoadBlock0Error as i32)
     });
 
     let context = v0::context::new_shared_context(db_pool, block0);

--- a/vit-servicing-station-tests/src/tests/bootstrap/parameters.rs
+++ b/vit-servicing-station-tests/src/tests/bootstrap/parameters.rs
@@ -24,6 +24,7 @@ pub fn no_in_settings_provided() {
         .failure()
         .code(ApplicationExitCode::DBConnectionError as i32);
 }
+
 #[test]
 pub fn in_settings_file_does_not_exist() {
     let mut command_builder: BootstrapCommandBuilder = Default::default();

--- a/vit-servicing-station-tests/src/tests/bootstrap/parameters.rs
+++ b/vit-servicing-station-tests/src/tests/bootstrap/parameters.rs
@@ -13,11 +13,16 @@ use std::{
     path::PathBuf,
     str::FromStr,
 };
+use vit_servicing_station_lib::server::exit_codes::ApplicationExitCode;
 
 #[test]
 pub fn no_in_settings_provided() {
     let command_builder: BootstrapCommandBuilder = Default::default();
-    command_builder.build().assert().failure();
+    command_builder
+        .build()
+        .assert()
+        .failure()
+        .code(ApplicationExitCode::DBConnectionError as i32);
 }
 #[test]
 pub fn in_settings_file_does_not_exist() {
@@ -29,7 +34,8 @@ pub fn in_settings_file_does_not_exist() {
         .in_settings_file(&non_existing_file)
         .build()
         .assert()
-        .failure();
+        .failure()
+        .code(ApplicationExitCode::LoadSettingsError as i32);
 }
 
 #[test]
@@ -51,7 +57,8 @@ pub fn in_settings_file_malformed() {
         .in_settings_file(&settings_file)
         .build()
         .assert()
-        .failure();
+        .failure()
+        .code(ApplicationExitCode::LoadSettingsError as i32);
 }
 
 pub fn remove_first_char_in_file(settings_file: &PathBuf) {
@@ -73,5 +80,6 @@ pub fn in_settings_file_with_malformed_path() {
         .in_settings_file(&non_existing_file)
         .build()
         .assert()
-        .failure();
+        .failure()
+        .code(ApplicationExitCode::LoadSettingsError as i32);
 }


### PR DESCRIPTION
By using specific error codes makes the bootstrapping testing of the application cleaner and easier.