### PR TITLE
Use OutputJson for i64 graphql atributtes

### DIFF
--- a/vit-servicing-station-lib/src/db/models/proposals.rs
+++ b/vit-servicing-station-lib/src/db/models/proposals.rs
@@ -43,8 +43,6 @@ pub struct Proposal {
     #[serde(alias = "proposalPublicKey")]
     pub proposal_public_key: String,
     #[serde(alias = "proposalFunds")]
-    #[serde(serialize_with = "crate::utils::serde::serialize_i64_as_str")]
-    #[serde(deserialize_with = "crate::utils::serde::deserialize_i64_from_str")]
     pub proposal_funds: i64,
     #[serde(alias = "proposalUrl")]
     pub proposal_url: String,
@@ -56,8 +54,6 @@ pub struct Proposal {
     #[serde(deserialize_with = "crate::utils::serde::deserialize_string_as_bytes")]
     pub chain_proposal_id: Vec<u8>,
     #[serde(alias = "chainProposalIndex")]
-    #[serde(serialize_with = "crate::utils::serde::serialize_i64_as_str")]
-    #[serde(deserialize_with = "crate::utils::serde::deserialize_i64_from_str")]
     pub chain_proposal_index: i64,
     #[serde(alias = "chainVoteOptions")]
     pub chain_vote_options: VoteOptions,

--- a/vit-servicing-station-lib/src/v0/endpoints/graphql/schema/proposals.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/graphql/schema/proposals.rs
@@ -67,8 +67,8 @@ impl Proposal {
         &self.proposal_public_key
     }
 
-    pub async fn proposal_funds(&self) -> i64 {
-        self.proposal_funds
+    pub async fn proposal_funds(&self) -> OutputJson<i64> {
+        OutputJson(self.proposal_funds)
     }
 
     pub async fn proposal_url(&self) -> &str {
@@ -91,8 +91,8 @@ impl Proposal {
         &self.chain_voteplan_id
     }
 
-    pub async fn chain_proposal_index(&self) -> i64 {
-        self.chain_proposal_index
+    pub async fn chain_proposal_index(&self) -> OutputJson<i64> {
+        OutputJson(self.chain_proposal_index)
     }
 
     pub async fn chain_voteplan_payload(&self) -> &str {


### PR DESCRIPTION
This PR is a rollback: Async-graphql lib removed the possibility to use scalar as 64bit integers (forcing them to be encoded as JSON strings instead of numbers). But they introduced this new OutputJson that add another workaround for the problem.