### PR TITLE
Cli backup db file before operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3256,6 +3256,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "structopt",
+ "tempfile",
  "vit-servicing-station-lib",
 ]
 

--- a/vit-servicing-station-cli/Cargo.toml
+++ b/vit-servicing-station-cli/Cargo.toml
@@ -13,8 +13,9 @@ chrono = "0.4.13"
 csv = "1.1"
 rand = "0.7.3"
 structopt = "0.3.14"
-vit-servicing-station-lib = { path = "../vit-servicing-station-lib" }
 serde = { version = "1.0", features = ["derive"] }
+tempfile = "3.1.0"
+vit-servicing-station-lib = { path = "../vit-servicing-station-lib" }
 
 [dev-dependencies]
 diesel = { version = "1.4.4", features = ["sqlite", "r2d2"] }

--- a/vit-servicing-station-cli/src/csv/loaders.rs
+++ b/vit-servicing-station-cli/src/csv/loaders.rs
@@ -135,6 +135,4 @@ impl ExecTask for CSVDataCmd {
 }
 
 #[cfg(test)]
-mod test {
-    use super::*;
-}
+mod test {}

--- a/vit-servicing-station-cli/src/db_utils.rs
+++ b/vit-servicing-station-cli/src/db_utils.rs
@@ -1,4 +1,7 @@
+use std::fs;
 use std::io;
+use std::io::{Read, Write};
+use tempfile;
 
 pub fn db_file_exists(db_url: &str) -> io::Result<()> {
     // check if db file exists
@@ -9,4 +12,17 @@ pub fn db_file_exists(db_url: &str) -> io::Result<()> {
         ));
     }
     Ok(())
+}
+
+pub fn backup_db_file(db_url: &str) -> io::Result<fs::File> {
+    db_file_exists(db_url)?;
+    let mut tmp_file = tempfile::tempfile()?;
+    tmp_file.write_all(&fs::read(db_url)?)?;
+    Ok(tmp_file)
+}
+
+pub fn restore_db_file(mut backup_file: fs::File, db_url: &str) -> io::Result<()> {
+    let mut buff = Vec::new();
+    backup_file.read(&mut buff)?;
+    fs::write(db_url, &buff)
 }

--- a/vit-servicing-station-cli/src/db_utils.rs
+++ b/vit-servicing-station-cli/src/db_utils.rs
@@ -14,15 +14,48 @@ pub fn db_file_exists(db_url: &str) -> io::Result<()> {
     Ok(())
 }
 
-pub fn backup_db_file(db_url: &str) -> io::Result<fs::File> {
+pub fn backup_db_file(db_url: &str) -> io::Result<tempfile::NamedTempFile> {
     db_file_exists(db_url)?;
-    let mut tmp_file = tempfile::tempfile()?;
-    tmp_file.write_all(&fs::read(db_url)?)?;
+    let mut tmp_file = tempfile::NamedTempFile::new()?;
+    let content = fs::read(db_url)?;
+    tmp_file.write_all(&content)?;
     Ok(tmp_file)
 }
 
-pub fn restore_db_file(mut backup_file: fs::File, db_url: &str) -> io::Result<()> {
+pub fn restore_db_file(backup_file: tempfile::NamedTempFile, db_url: &str) -> io::Result<()> {
+    let mut backup_file = backup_file.reopen()?;
     let mut buff = Vec::new();
-    backup_file.read(&mut buff)?;
+    backup_file.read_to_end(&mut buff)?;
     fs::write(db_url, &buff)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::db_utils::{backup_db_file, restore_db_file};
+    use std::{fs, io};
+
+    #[test]
+    fn backup_file() -> io::Result<()> {
+        let file_path = "./tmp_db.db";
+        let content = b"foo bar";
+        let content_vec = content.iter().cloned().collect::<Vec<u8>>();
+        // create a file with some content
+        fs::write(file_path, content)?;
+
+        // backup the file
+        let tmp_file = backup_db_file(file_path)?;
+
+        // write nonsense in old file
+        fs::write(file_path, b"bar foo")?;
+
+        // restore file and read content, hopefully is the old one
+        restore_db_file(tmp_file, file_path)?;
+        let backup_content = fs::read(file_path)?;
+        fs::remove_file(file_path)?;
+
+        // check written and actual content
+        assert_eq!(&content_vec, &backup_content);
+
+        Ok(())
+    }
 }

--- a/vit-servicing-station-cli/src/db_utils.rs
+++ b/vit-servicing-station-cli/src/db_utils.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::io;
 use std::io::{Read, Write};
-use tempfile;
 
 pub fn db_file_exists(db_url: &str) -> io::Result<()> {
     // check if db file exists


### PR DESCRIPTION
Diesel SQLite backend does not support some advanced features as updates. Nor it is easily configurable to use batching for cross tables operations. This solution should be enough for our needs (since we are not talking about huge database sizes). 
If at some point in the future we migrate to something like Postgress we could use some other approach.