### PR TITLE
Bump api version to 0.1.1

### DIFF
--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.3
 info:
   title: VIT as a Service Rest API
   description: VaaS Rest API v0
-  version: 0.0.1
+  version: 0.1.1
   contact:
     url: ''
 


### PR DESCRIPTION
Give this API a more ostentatious version number.
Retroactively considering the API sans challenges, released in 0.1.0, as version 0.1.0.