### PR TITLE
API: fix voteplan field chain_committee_end_time

### DIFF
--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -151,7 +151,7 @@ components:
         chain_vote_end_time:
           type: string
           format: date-time
-        chain_committee_end:
+        chain_committee_end_time:
           type: string
           format: date-time
         chain_voteplan_payload:


### PR DESCRIPTION
In the API spec, the `chain_committee_end_time` field, present on the voteplans model and in `voteplans.csv`, was mistakenly named `chain_committee_end`.