### PR TITLE
Remove challenge_type on proposals.csv loader and the data model

### DIFF
--- a/vit-servicing-station-cli/src/csv/models.rs
+++ b/vit-servicing-station-cli/src/csv/models.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 use vit_servicing_station_lib::db::models::proposals;
-use vit_servicing_station_lib::db::models::proposals::{Category, ChallengeType, Proposer};
+use vit_servicing_station_lib::db::models::proposals::{Category, Proposer};
 use vit_servicing_station_lib::db::models::vote_options::VoteOptions;
 
 #[derive(Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -137,8 +137,6 @@ impl From<Proposal> for proposals::Proposal {
             chain_vote_encryption_key: proposal.chain_vote_encryption_key,
             fund_id: proposal.fund_id,
             challenge_id: proposal.challenge_id,
-            // this is hardcoded here, it is not used since the value will not be saved into DB
-            challenge_type: ChallengeType::Simple,
             proposal_solution: proposal.proposal_solution,
             proposal_brief: proposal.proposal_brief,
             proposal_importance: proposal.proposal_importance,

--- a/vit-servicing-station-lib/src/db/queries/proposals.rs
+++ b/vit-servicing-station-lib/src/db/queries/proposals.rs
@@ -1,5 +1,6 @@
+use crate::db::models::proposals::{FullProposalInfo, Proposal};
+use crate::db::schema::proposals;
 use crate::db::{
-    models::proposals::Proposal, schema::proposals,
     views_schema::full_proposals_info::dsl as full_proposal_dsl,
     views_schema::full_proposals_info::dsl::full_proposals_info, DBConnection, DBConnectionPool,
 };
@@ -7,11 +8,13 @@ use crate::v0::errors::HandleError;
 use diesel::query_dsl::filter_dsl::FilterDsl;
 use diesel::{ExpressionMethods, Insertable, QueryResult, RunQueryDsl};
 
-pub async fn query_all_proposals(pool: &DBConnectionPool) -> Result<Vec<Proposal>, HandleError> {
+pub async fn query_all_proposals(
+    pool: &DBConnectionPool,
+) -> Result<Vec<FullProposalInfo>, HandleError> {
     let db_conn = pool.get().map_err(HandleError::DatabaseError)?;
     tokio::task::spawn_blocking(move || {
         full_proposals_info
-            .load::<Proposal>(&db_conn)
+            .load::<FullProposalInfo>(&db_conn)
             .map_err(|_e| HandleError::NotFound("proposals".to_string()))
     })
     .await
@@ -21,12 +24,12 @@ pub async fn query_all_proposals(pool: &DBConnectionPool) -> Result<Vec<Proposal
 pub async fn query_proposal_by_id(
     id: i32,
     pool: &DBConnectionPool,
-) -> Result<Proposal, HandleError> {
+) -> Result<FullProposalInfo, HandleError> {
     let db_conn = pool.get().map_err(HandleError::DatabaseError)?;
     tokio::task::spawn_blocking(move || {
         full_proposals_info
             .filter(full_proposal_dsl::id.eq(id))
-            .first::<Proposal>(&db_conn)
+            .first::<FullProposalInfo>(&db_conn)
             .map_err(|_e| HandleError::NotFound(format!("proposal with id {}", id)))
     })
     .await

--- a/vit-servicing-station-lib/src/v0/endpoints/graphql/routes.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/graphql/routes.rs
@@ -152,7 +152,6 @@ mod test {
                 chainCommitteeEndTime,
                 fundId,
                 challengeId
-                challengeType,
                 proposalSolution,
                 proposalBrief,
                 proposalImportance,
@@ -194,7 +193,6 @@ mod test {
             chainCommitteeEndTime,
             fundId,
             challengeId,
-            challengeType,
             proposalSolution,
             proposalBrief,
             proposalImportance,

--- a/vit-servicing-station-lib/src/v0/endpoints/graphql/schema/proposals.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/graphql/schema/proposals.rs
@@ -127,10 +127,6 @@ impl Proposal {
         self.challenge_id
     }
 
-    pub async fn challenge_type(&self) -> String {
-        self.challenge_type.to_string()
-    }
-
     pub async fn proposal_solution(&self) -> Option<String> {
         self.proposal_solution.clone()
     }

--- a/vit-servicing-station-lib/src/v0/endpoints/proposals/logic.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/proposals/logic.rs
@@ -1,12 +1,17 @@
-use crate::db::{models::proposals::Proposal, queries::proposals as proposals_queries};
+use crate::db::{models::proposals::FullProposalInfo, queries::proposals as proposals_queries};
 use crate::v0::{context::SharedContext, errors::HandleError};
 
-pub async fn get_all_proposals(context: SharedContext) -> Result<Vec<Proposal>, HandleError> {
+pub async fn get_all_proposals(
+    context: SharedContext,
+) -> Result<Vec<FullProposalInfo>, HandleError> {
     let pool = &context.read().await.db_connection_pool;
     proposals_queries::query_all_proposals(&pool).await
 }
 
-pub async fn get_proposal(id: i32, context: SharedContext) -> Result<Proposal, HandleError> {
+pub async fn get_proposal(
+    id: i32,
+    context: SharedContext,
+) -> Result<FullProposalInfo, HandleError> {
     let pool = &context.read().await.db_connection_pool;
     proposals_queries::query_proposal_by_id(id, &pool).await
 }

--- a/vit-servicing-station-tests/resources/graphql_requests/templates/proposal_by_id.txt
+++ b/vit-servicing-station-tests/resources/graphql_requests/templates/proposal_by_id.txt
@@ -22,7 +22,6 @@
                 proposerUrl,
                 proposerRelevantExperience
             },
-            challengeType,
             chainProposalId,
             chainProposalIndex,
             chainVoteOptions,
@@ -34,7 +33,6 @@
             chainCommitteeEndTime,
             fundId,
             challengeId,
-            challengeType,
             proposalSolution,
             proposalBrief,
             proposalImportance,

--- a/vit-servicing-station-tests/resources/graphql_requests/templates/proposals.txt
+++ b/vit-servicing-station-tests/resources/graphql_requests/templates/proposals.txt
@@ -31,7 +31,6 @@
         chainCommitteeEndTime,
         fundId
         challengeId
-        challengeType
         proposalSolution
         proposalBrief
         proposalImportance

--- a/vit-servicing-station-tests/src/common/clients/graphql/templates.rs
+++ b/vit-servicing-station-tests/src/common/clients/graphql/templates.rs
@@ -1,7 +1,7 @@
 use askama::Template;
 
 #[derive(Template)]
-#[template(path = "proposal_by_id.graphql.txt")]
+#[template(path = "proposal_by_id.txt")]
 pub struct ProposalById {
     pub id: u32,
 }

--- a/vit-servicing-station-tests/src/common/data/csv_converter.rs
+++ b/vit-servicing-station-tests/src/common/data/csv_converter.rs
@@ -81,7 +81,6 @@ impl CsvConverter {
             "chain_vote_end_time",
             "chain_committe",
             "challenge_id",
-            "challenge_type",
             "proposal_solution",
             "proposal_brief",
             "proposal_importance",
@@ -156,7 +155,6 @@ fn convert_proposal(proposal: &Proposal) -> Vec<String> {
         unix_timestamp_to_datetime(proposal.chain_vote_end_time).to_rfc3339(),
         unix_timestamp_to_datetime(proposal.chain_committee_end_time).to_rfc3339(),
         proposal.challenge_id.to_string(),
-        proposal.challenge_type.to_string(),
         proposal
             .proposal_solution
             .clone()

--- a/vit-servicing-station-tests/src/common/data/generator/arbitrary.rs
+++ b/vit-servicing-station-tests/src/common/data/generator/arbitrary.rs
@@ -222,7 +222,6 @@ impl ArbitraryGenerator {
             chain_vote_encryption_key: voteplan.chain_vote_encryption_key.clone(),
             fund_id: fund.id,
             challenge_id,
-            challenge_type: proposal_challenge_info.challenge_type,
             proposal_solution: proposal_challenge_info.proposal_solution,
             proposal_brief: proposal_challenge_info.proposal_brief,
             proposal_importance: proposal_challenge_info.proposal_importance,

--- a/vit-servicing-station-tests/src/common/data/generator/voting/plan.rs
+++ b/vit-servicing-station-tests/src/common/data/generator/voting/plan.rs
@@ -217,7 +217,6 @@ impl ValidVotePlanGenerator {
                     .unwrap_or_else(|| challenge.id.to_string())
                     .parse()
                     .unwrap(),
-                challenge_type: proposal_template.challenge_type,
                 proposal_solution: proposal_template.proposal_solution,
                 proposal_brief: proposal_template.proposal_brief,
                 proposal_importance: proposal_template.proposal_importance,

--- a/vit-servicing-station-tests/src/tests/rest/proposals.rs
+++ b/vit-servicing-station-tests/src/tests/rest/proposals.rs
@@ -22,7 +22,8 @@ pub fn get_proposal_by_id() -> Result<(), Box<dyn std::error::Error>> {
     let mut expected_proposal = data::proposals().first().unwrap().clone();
     let expected_challenge = data::challenges().first().unwrap().clone();
     expected_proposal.challenge_id = expected_challenge.id;
-    expected_proposal.challenge_type = expected_challenge.challenge_type.clone();
+    // TODO: challenge_type should be retrieved from the view data
+    // and checked against expected_challenge
     let (hash, token) = data::token();
 
     let db_path = DbBuilder::new()


### PR DESCRIPTION
`proposals.csv` does not need to have a `challenge_type` column, it is redundant with the data taken from `challenges.csv`.

Bring the model types closer to the database tables they represent and also to the OpenAPI declaration. `FullProposalInfo` is a data model extension of `Proposal`.
GraphQL and its tests had to drop the `challengeType` field on `Proposal`. It's should be done in a better way in GraphQL, anyway: full challenge data mounted as a subquery on Proposal.

Part of #135