### PR TITLE
Rest API additions

### DIFF
--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -149,6 +149,9 @@ components:
           type: string
         voting_power_info:
           type: string
+        voting_power_threshold:
+          type: integer
+          format: int64
         rewards_info:
           type: string
         fund_start_time:

--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -149,6 +149,8 @@ components:
           type: string
         voting_power_info:
           type: string
+          deprecated: true
+          description: "Deprecated, same as registration_snapshot_time"
         voting_power_threshold:
           type: integer
           format: int64
@@ -161,6 +163,9 @@ components:
           type: string
           format: date-time
         next_fund_start_time:
+          type: string
+          format: date-time
+        registration_snapshot_time:
           type: string
           format: date-time
         chain_vote_plans:

--- a/vit-servicing-station-lib/migrations/2020-05-22-112032_setup_db/up.sql
+++ b/vit-servicing-station-lib/migrations/2020-05-22-112032_setup_db/up.sql
@@ -4,7 +4,7 @@ create table funds
         primary key autoincrement,
     fund_name VARCHAR NOT NULL,
     fund_goal VARCHAR NOT NULL,
-    voting_power_info VARCHAR NOT NULL,
+    registration_snapshot_time BIGINT NOT NULL,
     voting_power_threshold BIGINT NOT NULL,
     rewards_info VARCHAR NOT NULL,
     fund_start_time BIGINT NOT NULL,

--- a/vit-servicing-station-lib/src/db/schema.rs
+++ b/vit-servicing-station-lib/src/db/schema.rs
@@ -24,7 +24,7 @@ table! {
         id -> Integer,
         fund_name -> Text,
         fund_goal -> Text,
-        voting_power_info -> Text,
+        registration_snapshot_time -> BigInt,
         voting_power_threshold -> BigInt,
         rewards_info -> Text,
         fund_start_time -> BigInt,

--- a/vit-servicing-station-tests/src/common/data/csv_converter.rs
+++ b/vit-servicing-station-tests/src/common/data/csv_converter.rs
@@ -22,11 +22,11 @@ impl CsvConverter {
             "fund_name",
             "voting_power_threshold",
             "fund_goal",
-            "voting_power_info",
             "rewards_info",
             "fund_start_time",
             "fund_end_time",
             "next_fund_start_time",
+            "registration_snapshot_time",
         ];
         let content: Vec<Vec<String>> = funds.iter().map(|x| convert_fund(x)).collect();
         self.build_file(headers, content, path)
@@ -189,11 +189,11 @@ fn convert_fund(fund: &Fund) -> Vec<String> {
         fund.fund_name.to_string(),
         fund.voting_power_threshold.to_string(),
         fund.fund_goal.to_string(),
-        fund.voting_power_info.to_string(),
         fund.rewards_info.to_string(),
         unix_timestamp_to_datetime(fund.fund_start_time).to_rfc3339(),
         unix_timestamp_to_datetime(fund.fund_end_time).to_rfc3339(),
         unix_timestamp_to_datetime(fund.next_fund_start_time).to_rfc3339(),
+        unix_timestamp_to_datetime(fund.registration_snapshot_time).to_rfc3339(),
     ]
 }
 

--- a/vit-servicing-station-tests/src/common/db/mod.rs
+++ b/vit-servicing-station-tests/src/common/db/mod.rs
@@ -142,12 +142,12 @@ impl<'a> DbInserter<'a> {
                 funds::id.eq(fund.id),
                 funds::fund_name.eq(fund.fund_name.clone()),
                 funds::fund_goal.eq(fund.fund_goal.clone()),
-                funds::voting_power_info.eq(fund.voting_power_info.clone()),
                 funds::voting_power_threshold.eq(fund.voting_power_threshold),
                 funds::rewards_info.eq(fund.rewards_info.clone()),
                 funds::fund_start_time.eq(fund.fund_start_time),
                 funds::fund_end_time.eq(fund.fund_end_time),
                 funds::next_fund_start_time.eq(fund.next_fund_start_time),
+                funds::registration_snapshot_time.eq(fund.registration_snapshot_time),
             );
 
             diesel::insert_into(funds::table)

--- a/vit-servicing-station-tests/src/tests/cli/load.rs
+++ b/vit-servicing-station-tests/src/tests/cli/load.rs
@@ -121,7 +121,7 @@ pub fn voting_snapshot_build() {
             .unwrap()
             .timestamp(),
     );
-    parameters.set_refresh_time(
+    parameters.set_registration_snapshot_time(
         NaiveDateTime::parse_from_str("2015-09-03 20:00:00", format)
             .unwrap()
             .timestamp(),


### PR DESCRIPTION
* Added `registration_snapshot_time`, replacing `voting_power_info` which duplicates the value for backward compatibility.
* Represented `voting_power_threshold` in the API description, previously omitted.