### PR TITLE
introduce voter groups within a single fund

### DIFF
--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -57,12 +57,12 @@ paths:
         "404":
           description: The requested fund was not found
 
-  /api/v0/proposals:
+  /api/v0/proposals/{voter_group_id}:
     post:
       summary: Get proposal by id
       tags: [ proposal ]
       description: |
-        Retrieves queried proposals.
+        Retrieves queried proposals for the provided voter group identifier.
       requestBody:
         description: List of voteplan id and indexes query
         required: true
@@ -93,13 +93,14 @@ paths:
                 items:
                   $ref: "#/components/schemas/ProposalWithChallengeInfo"
 
-  /api/v0/proposals/{id}:
+  /api/v0/proposals/{id}/{voter_group_id}:
     get:
       operationId: getProposal
       summary: Get proposal by id
       tags: [proposal]
       description: |
-        Retrieves information on the identified proposal.
+        Retrieves information on the identified proposal for a voter with the
+        provided voter group id.
       parameters:
         - in: path
           name: id
@@ -171,6 +172,11 @@ paths:
           schema:
             type: integer
           required: true
+        - in: path
+          name: voter_group_id
+          schema:
+            type: integer
+          required: true
       responses:
         "200":
           description: Valid response
@@ -230,6 +236,10 @@ components:
           items:
             $ref: "#/components/schemas/VotePlan"
           description: Vote plans registered for voting in this fund campaign.
+        groups:
+          type: array
+          items:
+            $ref: "#/components/schemas/VoterGroup"
         challenges:
           type: array
           items:
@@ -266,6 +276,11 @@ components:
           type: integer
           format: int32
           description: The fund ID this vote plan belongs to.
+        voting_token:
+          type: string
+          format: [0-9a-f]{56}(\.[0-9a-f]{1,64})?
+          description: |
+            The identifier of voting power token used withing this plan.
 
     Proposal:
       properties:
@@ -559,3 +574,16 @@ components:
           items:
               type: integer
               format: i64
+
+    VoterGroup:
+      properties:
+        id: integer
+          description: Unique identifier of this voter group
+        name: string
+          description: Voter group name
+        voting_token:
+          type: string
+          format: [0-9a-f]{56}(\.[0-9a-f]{1,64})?
+          description: |
+            The identifier of voting power token used withing this group. All vote plans within a
+            group are guaranteed to use the same token.

--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -62,7 +62,7 @@ paths:
       summary: Get proposal by id
       tags: [ proposal ]
       description: |
-        Retrieves queried proposals for the provided voter group identifier.
+        Retrieves queried proposals.
       requestBody:
         description: List of voteplan id and indexes query
         required: true
@@ -84,6 +84,13 @@ paths:
       tags: [proposal]
       description: |
         Lists all available proposals.
+      parameters:
+        - in: path
+          name: voter_group_id
+          description: Get proposals only for the specified vote group.
+          schema:
+            type: integer
+          required: false
       responses:
         "200":
           description: Valid response
@@ -93,14 +100,13 @@ paths:
                 items:
                   $ref: "#/components/schemas/ProposalWithChallengeInfo"
 
-  /api/v0/proposals/{id}/{voter_group_id}:
+  /api/v0/proposals/{id}:
     get:
       operationId: getProposal
       summary: Get proposal by id
       tags: [proposal]
       description: |
-        Retrieves information on the identified proposal for a voter with the
-        provided voter group id.
+        Retrieves information on the identified proposal.
       parameters:
         - in: path
           name: id
@@ -169,11 +175,6 @@ paths:
       parameters:
         - in: path
           name: proposal_id
-          schema:
-            type: integer
-          required: true
-        - in: path
-          name: voter_group_id
           schema:
             type: integer
           required: true


### PR DESCRIPTION
This PR introduces the concept of voter groups to the API. The idea behind this is that you can have multiple groups of voters voting within a single fund. Members of a group use the same voting token to vote on a given set of proposals.

Ideas/questions for API refactors given this change:

- Is `chain_vote_plans` field in `Fund` ever used?
- Shall we remove a bunch of fields duplicating `VotePlan` fields in `Proposal` and just include `chain_vote_plan` field there?