### PR TITLE
voter groups: alternative proposal

### DIFF
--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -57,12 +57,12 @@ paths:
         "404":
           description: The requested fund was not found
 
-  /api/v0/proposals:
+  /api/v0/proposals/{voter_group_id}:
     post:
       summary: Get proposal by id
       tags: [ proposal ]
       description: |
-        Retrieves queried proposals.
+        Retrieves queried proposals for the provided voter group identifier.
       requestBody:
         description: List of voteplan id and indexes query
         required: true
@@ -93,13 +93,14 @@ paths:
                 items:
                   $ref: "#/components/schemas/ProposalWithChallengeInfo"
 
-  /api/v0/proposals/{id}:
+  /api/v0/proposals/{id}/{voter_group_id}:
     get:
       operationId: getProposal
       summary: Get proposal by id
       tags: [proposal]
       description: |
-        Retrieves information on the identified proposal.
+        Retrieves information on the identified proposal for a voter with the
+        provided voter group id.
       parameters:
         - in: path
           name: id
@@ -171,6 +172,11 @@ paths:
           schema:
             type: integer
           required: true
+        - in: path
+          name: voter_group_id
+          schema:
+            type: integer
+          required: true
       responses:
         "200":
           description: Valid response
@@ -230,6 +236,10 @@ components:
           items:
             $ref: "#/components/schemas/VotePlan"
           description: Vote plans registered for voting in this fund campaign.
+        groups:
+          type: array
+          items:
+            $ref: "#/components/schemas/VoterGroup"
         challenges:
           type: array
           items:
@@ -266,6 +276,11 @@ components:
           type: integer
           format: int32
           description: The fund ID this vote plan belongs to.
+        voting_token:
+          type: string
+          format: [0-9a-f]{56}(\.[0-9a-f]{1,64})?
+          description: |
+            The identifier of voting power token used withing this plan.
 
     Proposal:
       properties:
@@ -559,3 +574,16 @@ components:
           items:
               type: integer
               format: i64
+
+    VoterGroup:
+      properties:
+        id: integer
+          description: Unique identifier of this voter group
+        name: string
+          description: Voter group name
+        voting_token:
+          type: string
+          format: [0-9a-f]{56}(\.[0-9a-f]{1,64})?
+          description: |
+            The identifier of voting power token used withing this group. All vote plans within a
+            group are guaranteed to use the same token.

--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -62,7 +62,7 @@ paths:
       summary: Get proposal by id
       tags: [ proposal ]
       description: |
-        Retrieves queried proposals for the provided voter group identifier.
+        Retrieves queried proposals.
       requestBody:
         description: List of voteplan id and indexes query
         required: true
@@ -84,6 +84,13 @@ paths:
       tags: [proposal]
       description: |
         Lists all available proposals.
+      parameters:
+        - in: path
+          name: voter_group_id
+          description: Get proposals only for the specified vote group.
+          schema:
+            type: integer
+          required: false
       responses:
         "200":
           description: Valid response
@@ -93,14 +100,13 @@ paths:
                 items:
                   $ref: "#/components/schemas/ProposalWithChallengeInfo"
 
-  /api/v0/proposals/{id}/{voter_group_id}:
+  /api/v0/proposals/{id}:
     get:
       operationId: getProposal
       summary: Get proposal by id
       tags: [proposal]
       description: |
-        Retrieves information on the identified proposal for a voter with the
-        provided voter group id.
+        Retrieves information on the identified proposal.
       parameters:
         - in: path
           name: id
@@ -169,11 +175,6 @@ paths:
       parameters:
         - in: path
           name: proposal_id
-          schema:
-            type: integer
-          required: true
-        - in: path
-          name: voter_group_id
           schema:
             type: integer
           required: true

--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -57,7 +57,7 @@ paths:
         "404":
           description: The requested fund was not found
 
-  /api/v0/proposals/{voter_group_id}:
+  /api/v0/proposals:
     post:
       summary: Get proposal by id
       tags: [ proposal ]
@@ -84,13 +84,6 @@ paths:
       tags: [proposal]
       description: |
         Lists all available proposals.
-      parameters:
-        - in: path
-          name: voter_group_id
-          description: Get proposals only for the specified vote group.
-          schema:
-            type: integer
-          required: false
       responses:
         "200":
           description: Valid response
@@ -283,54 +276,16 @@ components:
           description: |
             The identifier of voting power token used withing this plan.
 
-    Proposal:
+    ChainProposalInfo:
       properties:
-        internal_id:
+        voter_group_id:
           type: integer
-          format: int32
-          description: The API identifier for this proposal.
-        proposal_id:
-          type: string
-          description: Unique identifier for this proposal.
-        proposal_category:
-          type: object
-          properties:
-            category_id:
-              type: string
-            category_name:
-              type: string
-            category_description:
-              type: string
-        proposal_title:
-          type: string
-          description: Short title of the proposal.
-        proposal_summary:
-          type: string
-          description: Brief description of the proposal.
+          description: |
+            The identifier of the voter group this on-chain proposal is intended to be used by.
         proposal_public_key:
           type: string
           format: binary
-        proposal_funds:
-          type: integer
-          format: int64
-          description: The amount of funds requested by this proposal.
-        proposal_url:
-          type: string
-          description: URL to a web page with details on this proposal.
-        proposal_files:
-          type: string
-        proposer:
-          type: object
-          properties:
-            proposer_name:
-              type: string
-              description: Name of the author of the proposal.
-            proposer_email:
-              type: string
-              description: Email address of the author of the proposal.
-            proposer_url:
-              type: string
-              description: URL to a web resource with details about the author of the proposal.
+          description: Public key for voting privacy preserving protocol (if enabled).
         chain_proposal_id:
           type: string
           description: Identifier of the proposal on the blockchain.
@@ -360,6 +315,57 @@ components:
           type: string
           description: |
             Whether the voting is done using the public or the privacy-preserving protocol.
+
+    Proposal:
+      properties:
+        internal_id:
+          type: integer
+          format: int32
+          description: The API identifier for this proposal.
+        proposal_id:
+          type: string
+          description: Unique identifier for this proposal.
+        proposal_category:
+          type: object
+          properties:
+            category_id:
+              type: string
+            category_name:
+              type: string
+            category_description:
+              type: string
+        proposal_title:
+          type: string
+          description: Short title of the proposal.
+        proposal_summary:
+          type: string
+          description: Brief description of the proposal.
+        proposal_funds:
+          type: integer
+          format: int64
+          description: The amount of funds requested by this proposal.
+        proposal_url:
+          type: string
+          description: URL to a web page with details on this proposal.
+        proposal_files:
+          type: string
+        proposer:
+          type: object
+          properties:
+            proposer_name:
+              type: string
+              description: Name of the author of the proposal.
+            proposer_email:
+              type: string
+              description: Email address of the author of the proposal.
+            proposer_url:
+              type: string
+              description: URL to a web resource with details about the author of the proposal.
+        chain_info:
+          type: array
+          description: Corresponding on-chain proposals for different voter groups.
+          items:
+            $ref: "#/components/schemas/ChainProposalInfo"
 
     ChallengeType:
       type: string


### PR DESCRIPTION
Introduce 1-to-many relationship between proposal data and on-chain proposals. This enables users from different groups to vote on the same proposal while reducing data duplication in the database.

Built on top of https://github.com/input-output-hk/vit-servicing-station/pull/198