### PR TITLE
Improve Nix handling to align with jormungandr repo template

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: '00:00'
+      timezone: UTC
+    open-pull-requests-limit: 10
+    commit-message:
+        prefix: "chore"
+        include: "scope"

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,19 @@
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v8

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
+book
 /target
+/vendor
+/result
+/.idea/
+/.vscode/
+/.direnv/
+/.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,68 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646480205,
+        "narHash": "sha256-kekOlTlu45vuK2L9nq8iVN17V3sB0WWPqTTW3a2SQG0=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "bff2832ec341cf30acb3a4d3e2e7f1f7b590116a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1647605581,
+        "narHash": "sha256-56AaI1Zqgxuu+b8o3RbQBP2wtdn3/mQ23eLnkxOtHm8=",
+        "owner": "yusdacra",
+        "repo": "naersk",
+        "rev": "7882e303c4904664194236c921365b4d6b86b9bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "ref": "feat/cargolock-git-deps",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1639347265,
-        "narHash": "sha256-q5feWoC64+h6T6J89o2HJJ8DOnB/4vwMODBlZIgeIlA=",
+        "lastModified": 1647893727,
+        "narHash": "sha256-pOi7VdCb+s5Cwh5CS7YEZVRgH9uCmE87J5W7iXv29Ck=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0bf5f888d377dd2f36d90340df6dc9f035aaada",
+        "rev": "1ec61dd4167f04be8d05c45780818826132eea0d",
         "type": "github"
       },
       "original": {
@@ -16,24 +72,59 @@
         "type": "github"
       }
     },
-    "root": {
+    "pre-commit-hooks": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
-      }
-    },
-    "utils": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1633020561,
-        "narHash": "sha256-4uAiRqL9nP3d/NQ8VBqjQ5iZypHaM+X/FyWpXVXkwTA=",
-        "owner": "kreisys",
-        "repo": "flake-utils",
-        "rev": "2923532a276a5595ee64376ec1b3db6ed8503c52",
+        "lastModified": 1646153636,
+        "narHash": "sha256-AlWHMzK+xJ1mG267FdT8dCq/HvLCA6jwmx2ZUy5O8tY=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "b6bc0b21e1617e2b07d8205e7fae7224036dfa4b",
         "type": "github"
       },
       "original": {
-        "owner": "kreisys",
-        "repo": "flake-utils",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1648089132,
+        "narHash": "sha256-/IhAlfr3MaAfFl2h269xLdY/ePIb9mKGRX2rs8fCn3M=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "1aa91c06c8d94f22114b9541cd97fe6be31c1b4b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,38 +1,172 @@
 {
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    utils.url = "github:kreisys/flake-utils";
-  };
-  outputs = { self, nixpkgs, utils }:
-    let
-      workspaceCargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-      inherit (workspaceCargo.workspace) members;
-    in utils.lib.simpleFlake {
-      inherit nixpkgs;
-      systems = [ "x86_64-linux" "aarch64-linux" ];
-      preOverlays = [ ];
-      overlay = final: prev:
-        let inherit (prev) lib;
-        in lib.listToAttrs (lib.forEach members (member:
-          lib.nameValuePair member (prev.rustPlatform.buildRustPackage {
-            inherit ((builtins.fromTOML
-              (builtins.readFile (./. + "/${member}/Cargo.toml"))).package)
-              name version;
-            src = ./.;
-            cargoSha256 = "1npj9j6na14h4m052qsrd56dw8d1p4ssv0wiq1bdx2726j1wbgac";
-            nativeBuildInputs = with final; [ pkg-config protobuf rustfmt ];
-            buildInputs = with final; [ openssl ];
-            PROTOC = "${final.protobuf}/bin/protoc";
-            PROTOC_INCLUDE = "${final.protobuf}/include";
-          })));
-      packages = { vit-servicing-station-cli, vit-servicing-station-lib
-        , vit-servicing-station-server, vit-servicing-station-tests }@pkgs:
-        pkgs;
-      devShell = { mkShell, rustc, cargo, pkg-config, openssl, protobuf }:
-        mkShell {
-          PROTOC = "${protobuf}/bin/protoc";
-          PROTOC_INCLUDE = "${protobuf}/include";
-          buildInputs = [ rustc cargo pkg-config openssl protobuf ];
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.gitignore.url = "github:hercules-ci/gitignore.nix";
+  inputs.gitignore.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+  inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.pre-commit-hooks.inputs.flake-utils.follows = "flake-utils";
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+  inputs.rust-overlay.inputs.flake-utils.follows = "flake-utils";
+  inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  # XXX: https://github.com/nix-community/naersk/pull/167
+  #inputs.naersk.url = "github:nix-community/naersk";
+  inputs.naersk.url = "github:yusdacra/naersk/feat/cargolock-git-deps";
+  inputs.naersk.inputs.nixpkgs.follows = "nixpkgs";
+
+  nixConfig.extra-substituters = [
+    "https://hydra.iohk.io"
+    "https://vit-ops.cachix.org"
+  ];
+  nixConfig.extra-trusted-public-keys = [
+    "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+    "vit-ops.cachix.org-1:LY84nIKdW7g1cvhJ6LsupHmGtGcKAlUXo+l1KByoDho="
+  ];
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    gitignore,
+    pre-commit-hooks,
+    rust-overlay,
+    naersk,
+  }:
+    flake-utils.lib.eachSystem
+    [
+      flake-utils.lib.system.x86_64-linux
+      flake-utils.lib.system.aarch64-linux
+    ]
+    (
+      system: let
+        readTOML = file: builtins.fromTOML (builtins.readFile file);
+        workspaceCargo = readTOML ./Cargo.toml;
+
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [(import rust-overlay)];
         };
-    };
+
+        rust = let
+          _rust = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "rust-analysis"
+              "rls-preview"
+              "rustfmt-preview"
+              "clippy-preview"
+            ];
+          };
+        in
+          pkgs.buildEnv {
+            name = _rust.name;
+            inherit (_rust) meta;
+            buildInputs = [pkgs.makeWrapper];
+            paths = [_rust];
+            pathsToLink = ["/" "/bin"];
+            # XXX: This is needed because cargo and clippy commands need to
+            # also be aware of other binaries in order to work properly.
+            # https://github.com/cachix/pre-commit-hooks.nix/issues/126
+            postBuild = ''
+              for i in $out/bin/*; do
+                wrapProgram "$i" --prefix PATH : "$out/bin"
+              done
+            '';
+          };
+
+        naersk-lib = naersk.lib."${system}".override {
+          cargo = rust;
+          rustc = rust;
+        };
+
+        mkPackage = name: let
+          pkgCargo = readTOML ./${name}/Cargo.toml;
+          cargoOptions = [
+            "--package"
+            name
+          ];
+        in
+          naersk-lib.buildPackage {
+            root = gitignore.lib.gitignoreSource self;
+
+            cargoBuildOptions = x: x ++ cargoOptions;
+            cargoTestOptions = x: x ++ cargoOptions;
+
+            PROTOC = "${pkgs.protobuf}/bin/protoc";
+            PROTOC_INCLUDE = "${pkgs.protobuf}/include";
+
+            nativeBuildInputs = with pkgs; [
+              pkg-config
+              protobuf
+              rustfmt
+            ];
+
+            buildInputs = with pkgs; [
+              openssl
+            ];
+          };
+
+        workspace =
+          builtins.listToAttrs
+          (
+            builtins.map
+            (name: {
+              inherit name;
+              value = mkPackage name;
+            })
+            workspaceCargo.workspace.members
+          );
+
+        pre-commit = pre-commit-hooks.lib.${system}.run {
+          src = self;
+          hooks = {
+            alejandra = {
+              enable = true;
+            };
+            rustfmt = {
+              enable = true;
+              entry = pkgs.lib.mkForce "${rust}/bin/cargo-fmt fmt -- --check --color always";
+            };
+          };
+        };
+
+        warnToUpdateNix = pkgs.lib.warn "Consider updating to Nix > 2.7 to remove this warning!";
+      in rec {
+        packages = {
+          inherit
+            (workspace)
+            vit-servicing-station-cli
+            vit-servicing-station-lib
+            vit-servicing-station-server
+            vit-servicing-station-tests
+            ;
+          default = workspace.vit-servicing-station-server;
+        };
+
+        devShells.default = pkgs.mkShell {
+          PROTOC = "${pkgs.protobuf}/bin/protoc";
+          PROTOC_INCLUDE = "${pkgs.protobuf}/include";
+          buildInputs =
+            [rust]
+            ++ (with pkgs; [
+              pkg-config
+              openssl
+              protobuf
+            ]);
+          shellHook =
+            pre-commit.shellHook
+            + ''
+              echo "=== vit-servicing-station development shell ==="
+              echo "Info: Git hooks can be installed using \`pre-commit install\`"
+            '';
+        };
+
+        checks.pre-commit = pre-commit;
+
+        hydraJobs = packages;
+
+        defaultPackage = warnToUpdateNix packages.default;
+        devShell = warnToUpdateNix devShells.default;
+      }
+    );
 }


### PR DESCRIPTION
Based on the template that @garbas created for the jormungandr, propagating changes to the servicing station as well, in recap:

* Update github actions on a daily basis.
* New github workflow that updates flake inputs weekly.
* Use upstream [flake-utils](https://github.com/numtide/flake-utils) (no need to use the fork)
* Use [gitignore.nix](https://github.com/hercules-ci/gitignore.nix) to filter out not needed source files. That
* Use [direnv](https://direnv.net/) to automatically enter the nix development environment.
* Use [pre-commit.nix](https://github.com/cachix/pre-commit-hooks.nix/) to force rust and nix formatter.
* Use [rust-overlay](https://github.com/oxalica/rust-overlay) to follow latest stable rust compiler.
* Use [naersk](https://github.com/nix-community/naersk) to load cargo dependencies from Cargo.lock file.
