### PR TITLE
add another build method for DbBuilder.

### DIFF
--- a/vit-servicing-station-tests/src/common/startup/db.rs
+++ b/vit-servicing-station-tests/src/common/startup/db.rs
@@ -145,11 +145,12 @@ impl DbBuilder {
     }
 
     pub fn build(&self, temp_dir: &TempDir) -> Result<PathBuf, DbBuilderError> {
-        let db = temp_dir.child("vit_station.db");
-        let db_path = db
-            .path()
-            .to_str()
-            .ok_or(DbBuilderError::CannotExtractTempPath)?;
+        self.build_into_path(temp_dir.child("vit_station.db").path())
+    }
+
+    pub fn build_into_path<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, DbBuilderError> {
+        let path = path.as_ref();
+        let db_path = path.to_str().ok_or(DbBuilderError::CannotExtractTempPath)?;
         println!("Building db in {:?}...", db_path);
 
         let connection = SqliteConnection::establish(db_path)?;
@@ -159,7 +160,7 @@ impl DbBuilder {
         self.try_insert_proposals(&connection)?;
         self.try_insert_challenges(&connection)?;
         self.try_insert_reviews(&connection)?;
-        Ok(PathBuf::from(db.path()))
+        Ok(path.to_path_buf())
     }
 }
 

--- a/vit-servicing-station-tests/src/common/startup/db.rs
+++ b/vit-servicing-station-tests/src/common/startup/db.rs
@@ -17,6 +17,8 @@ use crate::common::{
 use vit_servicing_station_lib::db::models::community_advisors_reviews::AdvisorReview;
 use vit_servicing_station_lib::db::models::proposals::FullProposalInfo;
 
+const VIT_STATION_DB: &str = "vit_station.db";
+
 pub struct DbBuilder {
     migrations_folder: Option<PathBuf>,
     tokens: Option<Vec<ApiTokenData>>,
@@ -145,7 +147,7 @@ impl DbBuilder {
     }
 
     pub fn build(&self, temp_dir: &TempDir) -> Result<PathBuf, DbBuilderError> {
-        self.build_into_path(temp_dir.child("vit_station.db").path())
+        self.build_into_path(temp_dir.child(VIT_STATION_DB).path())
     }
 
     pub fn build_into_path<P: AsRef<Path>>(&self, path: P) -> Result<PathBuf, DbBuilderError> {


### PR DESCRIPTION
There is a need to build db not only to temporary folder, but also to arbitrary path. This is needed especially in vitup which is also using DbBuilder to create database file used for voting. Currently it is built to temporary folder and then it has to be copied to target folder. This pr will help to skip copy step and create database in final destination