### PR TITLE
Remove windows-gnu target from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,6 @@ jobs:
         cross: [false]
         include:
           # Windows
-          - config: {os: windows-latest, target: x86_64-pc-windows-gnu}
-            toolchain: stable-x86_64-pc-windows-gnu
-            cross: false
           - config: {os: windows-latest, target: x86_64-pc-windows-msvc}
             toolchain: stable-x86_64-pc-windows-msvc
             cross: false


### PR DESCRIPTION
Remove windows-gnu as it's not tested on PRs, not built for on
Jormungandr or catalyst-toolbox and is currently failing