### PR TITLE
serve challenges following insertion order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3978,6 +3978,7 @@ dependencies = [
  "r2d2",
  "rand 0.7.3",
  "serde",
+ "serde_json",
  "structopt",
  "tempfile",
  "thiserror",

--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -164,7 +164,7 @@ paths:
       summary: Get all available challenges
       tags: [challenge]
       description: |
-        Lists all available challenges.
+        Lists all available challenges following insertion order.
       responses:
         "200":
           description: Valid response

--- a/vit-servicing-station-cli/Cargo.toml
+++ b/vit-servicing-station-cli/Cargo.toml
@@ -16,6 +16,7 @@ rand = "0.7.3"
 r2d2 = "0.8"
 structopt = "0.3.14"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 tempfile = "3.1.0"
 thiserror = "1.0"
 vit-servicing-station-lib = { path = "../vit-servicing-station-lib" }

--- a/vit-servicing-station-cli/src/csv/loaders.rs
+++ b/vit-servicing-station-cli/src/csv/loaders.rs
@@ -2,7 +2,6 @@ use crate::db_utils::{backup_db_file, restore_db_file};
 use crate::{db_utils::db_file_exists, task::ExecTask};
 use csv::Trim;
 use serde::de::DeserializeOwned;
-use std::collections::HashMap;
 use std::convert::TryInto;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -14,7 +13,7 @@ use vit_servicing_station_lib::db::models::proposals::{
 };
 use vit_servicing_station_lib::db::{
     load_db_connection_pool,
-    models::{challenges::Challenge, funds::Fund, proposals::Proposal, voteplans::Voteplan},
+    models::{funds::Fund, proposals::Proposal, voteplans::Voteplan},
 };
 
 #[derive(Error, Debug)]
@@ -107,11 +106,8 @@ impl CsvDataCmd {
         let funds = CsvDataCmd::load_from_csv::<Fund>(funds_path)?;
 
         let mut voteplans = CsvDataCmd::load_from_csv::<Voteplan>(voteplans_path)?;
-        let mut challenges: HashMap<i32, Challenge> =
-            CsvDataCmd::load_from_csv::<Challenge>(challenges_path)?
-                .into_iter()
-                .map(|c| (c.id, c))
-                .collect();
+        let mut challenges =
+            CsvDataCmd::load_from_csv::<super::models::Challenge>(challenges_path)?;
         let csv_proposals = CsvDataCmd::load_from_csv::<super::models::Proposal>(proposals_path)?;
         let reviews = CsvDataCmd::load_from_csv::<super::models::AdvisorReview>(reviews_path)?
             .into_iter()
@@ -125,7 +121,8 @@ impl CsvDataCmd {
 
         for proposal in csv_proposals {
             let challenge_type = challenges
-                .get(&proposal.challenge_id)
+                .iter()
+                .find(|c| proposal.challenge_id == c.id)
                 .ok_or_else(|| {
                     std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
@@ -181,7 +178,7 @@ impl CsvDataCmd {
         }
 
         // apply fund id to challenges
-        for challenge in challenges.values_mut() {
+        for challenge in challenges.iter_mut() {
             challenge.fund_id = fund.id;
         }
 
@@ -212,7 +209,10 @@ impl CsvDataCmd {
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{}", e)))?;
 
         vit_servicing_station_lib::db::queries::challenges::batch_insert_challenges(
-            &challenges.values().cloned().collect::<Vec<Challenge>>(),
+            &challenges
+                .into_iter()
+                .map(|c| c.into_db_challenge_values())
+                .collect::<Vec<_>>(),
             &db_conn,
         )
         .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{}", e)))?;

--- a/vit-servicing-station-lib/migrations/2020-05-22-112032_setup_db/up.sql
+++ b/vit-servicing-station-lib/migrations/2020-05-22-112032_setup_db/up.sql
@@ -84,8 +84,9 @@ create table api_tokens
 
 create table challenges
 (
-    id INTEGER NOT NULL
+    internal_id INTEGER NOT NULL
         primary key autoincrement,
+    id INTEGER NOT NULL UNIQUE,
     challenge_type VARCHAR NOT NULL,
     title VARCHAR NOT NULL,
     description VARCHAR NOT NULL,

--- a/vit-servicing-station-lib/src/db/models/challenges.rs
+++ b/vit-servicing-station-lib/src/db/models/challenges.rs
@@ -10,6 +10,9 @@ pub struct ChallengeHighlights {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Challenge {
+    #[serde(alias = "internalId")]
+    // this is used only to retain the original insert order
+    pub internal_id: i32,
     pub id: i32,
     #[serde(alias = "challengeType")]
     pub challenge_type: ChallengeType,
@@ -28,38 +31,41 @@ pub struct Challenge {
 
 impl Queryable<challenges::SqlType, Db> for Challenge {
     type Row = (
-        // 0 -> id
+        // 0 -> internal_id
         i32,
-        // 1 -> challenge_type
-        String,
-        // 1 -> title
-        String,
-        // 2 -> description
-        String,
-        // 3 -> rewards_total
-        i64,
-        // 4 -> proposers_rewards
-        i64,
-        // 5 -> fund_id
+        // 1 -> id
         i32,
-        // 6 -> fund_url
+        // 2 -> challenge_type
         String,
-        // 7 -> challenge_highlights
+        // 3 -> title
+        String,
+        // 4 -> description
+        String,
+        // 5 -> rewards_total
+        i64,
+        // 6 -> proposers_rewards
+        i64,
+        // 7 -> fund_id
+        i32,
+        // 8 -> fund_url
+        String,
+        // 9 -> challenge_highlights
         Option<String>,
     );
 
     fn build(row: Self::Row) -> Self {
         Challenge {
-            id: row.0,
-            challenge_type: row.1.parse().unwrap(),
-            title: row.2,
-            description: row.3,
-            rewards_total: row.4,
-            proposers_rewards: row.5,
-            fund_id: row.6,
-            challenge_url: row.7,
+            internal_id: row.0,
+            id: row.1,
+            challenge_type: row.2.parse().unwrap(),
+            title: row.3,
+            description: row.4,
+            rewards_total: row.5,
+            proposers_rewards: row.6,
+            fund_id: row.7,
+            challenge_url: row.8,
             // It should be ensured that the content is valid json
-            highlights: row.8.and_then(|v| serde_json::from_str(&v).ok()),
+            highlights: row.9.and_then(|v| serde_json::from_str(&v).ok()),
         }
     }
 }
@@ -104,6 +110,7 @@ pub mod test {
         const CHALLENGE_ID: i32 = 9001;
         const REWARDS_TOTAL: i64 = 100500;
         Challenge {
+            internal_id: 1,
             id: CHALLENGE_ID,
             challenge_type: ChallengeType::CommunityChoice,
             title: "challenge title".to_string(),

--- a/vit-servicing-station-lib/src/db/schema.rs
+++ b/vit-servicing-station-lib/src/db/schema.rs
@@ -8,6 +8,7 @@ table! {
 
 table! {
     challenges (id) {
+        internal_id -> Integer,
         id -> Integer,
         challenge_type -> Text,
         title -> Text,

--- a/vit-servicing-station-tests/src/common/data/generator/arbitrary/snapshot_generator.rs
+++ b/vit-servicing-station-tests/src/common/data/generator/arbitrary/snapshot_generator.rs
@@ -266,6 +266,7 @@ impl ArbitrarySnapshotGenerator {
 
         vec![
             Challenge {
+                internal_id: first_challenge.internal_id,
                 id: simple_id.abs(),
                 challenge_type: ChallengeType::Simple,
                 title: first_challenge.title,
@@ -277,6 +278,7 @@ impl ArbitrarySnapshotGenerator {
                 highlights: self.template_generator.gen_highlights(),
             },
             Challenge {
+                internal_id: second_challenge.internal_id,
                 id: community_choice_id.abs(),
                 challenge_type: ChallengeType::CommunityChoice,
                 title: second_challenge.title,
@@ -295,6 +297,7 @@ impl ArbitrarySnapshotGenerator {
         let challenge = self.template_generator.next_challenge();
 
         Challenge {
+            internal_id: challenge.internal_id,
             id: id.abs(),
             challenge_type: ChallengeType::CommunityChoice,
             title: challenge.title,

--- a/vit-servicing-station-tests/src/common/data/generator/voting/generator.rs
+++ b/vit-servicing-station-tests/src/common/data/generator/voting/generator.rs
@@ -66,6 +66,7 @@ impl ValidVotePlanGenerator {
         let challenges: Vec<Challenge> = std::iter::from_fn(|| {
             let challenge_data = template_generator.next_challenge();
             Some(Challenge {
+                internal_id: challenge_data.internal_id,
                 id: challenge_data.id.parse().unwrap(),
                 challenge_type: challenge_data.challenge_type,
                 title: challenge_data.title,

--- a/vit-servicing-station-tests/src/common/data/generator/voting/template/arbitrary.rs
+++ b/vit-servicing-station-tests/src/common/data/generator/voting/template/arbitrary.rs
@@ -188,7 +188,8 @@ impl ValidVotingTemplateGenerator for ArbitraryValidVotingTemplateGenerator {
 
     fn next_challenge(&mut self) -> ChallengeTemplate {
         let challenge = ChallengeTemplate {
-            id: self.next_challenge_id().to_string(),
+            internal_id: self.next_challenge_id(),
+            id: self.generator.id().to_string(),
             challenge_type: self.challenge_type(),
             title: CatchPhase().fake::<String>(),
             description: Buzzword().fake::<String>(),

--- a/vit-servicing-station-tests/src/common/data/generator/voting/template/mod.rs
+++ b/vit-servicing-station-tests/src/common/data/generator/voting/template/mod.rs
@@ -50,6 +50,7 @@ pub struct ProposalTemplate {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ChallengeTemplate {
+    pub internal_id: i32,
     pub id: String,
     pub challenge_type: ChallengeType,
     pub title: String,

--- a/vit-servicing-station-tests/src/common/db/mod.rs
+++ b/vit-servicing-station-tests/src/common/db/mod.rs
@@ -166,22 +166,6 @@ impl<'a> DbInserter<'a> {
                     .map_err(DbInserterError::DieselError)?;
             }
 
-            for challenge in &fund.challenges {
-                let values = (
-                    challenges::id.eq(challenge.id),
-                    challenges::challenge_type.eq(challenge.challenge_type.to_string()),
-                    challenges::title.eq(challenge.title.clone()),
-                    challenges::description.eq(challenge.description.clone()),
-                    challenges::rewards_total.eq(challenge.rewards_total),
-                    challenges::fund_id.eq(challenge.fund_id),
-                    challenges::challenge_url.eq(challenge.challenge_url.clone()),
-                );
-                diesel::insert_or_ignore_into(challenges::table)
-                    .values(values)
-                    .execute(self.connection)
-                    .map_err(DbInserterError::DieselError)?;
-            }
-
             for goal in &fund.goals {
                 diesel::insert_or_ignore_into(goals::table)
                     .values(InsertGoal::from(goal))

--- a/vit-servicing-station-tests/src/tests/rest/funds.rs
+++ b/vit-servicing-station-tests/src/tests/rest/funds.rs
@@ -37,8 +37,7 @@ pub fn get_funds_by_id() -> Result<(), Box<dyn std::error::Error>> {
     let rest_client = server.rest_client_with_token(&hash);
 
     let actual_fund = rest_client.fund(&expected_fund.id.to_string())?;
-
-    expected_fund.challenges.sort_by_key(|c| c.id);
+    expected_fund.challenges.sort_by_key(|c| c.internal_id);
     assert_eq!(expected_fund, actual_fund);
 
     let rest_client: RawRestClient = server.rest_client_with_token(&hash).into();


### PR DESCRIPTION
Guarantee that challenges will be served in the insertion order.
I had to add another field `internal_id` to use as the primary key as SQLite does not allow `autoincrement` on fields different from `INTEGER PRIMARY KEY` (`autoincrement` is actually backed by `rowid`). 