### PR TITLE
sort the challenges in the fund object by insertion order

### DIFF
--- a/vit-servicing-station-lib/src/db/queries/funds.rs
+++ b/vit-servicing-station-lib/src/db/queries/funds.rs
@@ -31,6 +31,7 @@ fn join_fund(
 
     fund.challenges = challenges_dsl::challenges
         .filter(challenges_dsl::fund_id.eq(id))
+        .order_by(challenges_dsl::internal_id.asc())
         .load::<Challenge>(db_conn)
         .map_err(|_e| HandleError::NotFound("Error loading challenges".to_string()))?;
 


### PR DESCRIPTION
I think this was missing from #240 

This causes some sporadic failures in `get_funds_by_id`, when the randomly generated ids are in the inverse order than the insertion.

It's not a big deal anyway because the app doesn't use this though, maybe the challenges in the fund should be removed altogether, but idk.