### PR TITLE
remove windows gnu target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,10 +122,6 @@ jobs:
         toolchain: [stable]
         cross: [false]
         include:
-          # Windows
-          - config: {os: windows-latest, target: x86_64-pc-windows-gnu}
-            toolchain: stable-x86_64-pc-windows-gnu
-            cross: false
           - config: {os: windows-latest, target: x86_64-pc-windows-msvc}
             toolchain: stable-x86_64-pc-windows-msvc
             cross: false


### PR DESCRIPTION
The Windows GNU target fails to compile due to an unsatisfied link error, removing this target because we don't need it anyway