### PR TITLE
remove into_persistent calls

### DIFF
--- a/vit-servicing-station-tests/src/tests/bootstrap/arguments/out_settings.rs
+++ b/vit-servicing-station-tests/src/tests/bootstrap/arguments/out_settings.rs
@@ -48,7 +48,7 @@ pub fn out_settings_file_override() {
 #[test]
 #[ignore = "issue in comment for https://github.com/input-output-hk/vit-servicing-station/pull/75"]
 pub fn out_settings_file_from_cmdline() {
-    let temp_dir = TempDir::new().unwrap().into_persistent();
+    let temp_dir = TempDir::new().unwrap();
     let (_, settings) = example_settings_file(&temp_dir);
     let out_settings_file = temp_dir.child("settings.json");
 

--- a/vit-servicing-station-tests/src/tests/bootstrap/mod.rs
+++ b/vit-servicing-station-tests/src/tests/bootstrap/mod.rs
@@ -8,7 +8,7 @@ pub mod arguments;
 
 #[test]
 pub fn bootstrap_with_random_data() -> Result<(), Box<dyn std::error::Error>> {
-    let temp_dir = TempDir::new().unwrap().into_persistent();
+    let temp_dir = TempDir::new().unwrap();
     let snapshot = data::ArbitrarySnapshotGenerator::default().snapshot();
     let db_path = DbBuilder::new().with_snapshot(&snapshot).build(&temp_dir)?;
 

--- a/vit-servicing-station-tests/src/tests/cli/load.rs
+++ b/vit-servicing-station-tests/src/tests/cli/load.rs
@@ -105,7 +105,7 @@ pub fn load_data_test() {
 
 #[test]
 pub fn voting_snapshot_build() {
-    let temp_dir = TempDir::new().unwrap().into_persistent();
+    let temp_dir = TempDir::new().unwrap();
     let mut db_builder = DbBuilder::new();
     db_builder.with_snapshot(&multivoteplan_snapshot());
     db_builder.build(&temp_dir).unwrap();

--- a/vit-servicing-station-tests/src/tests/cli/token.rs
+++ b/vit-servicing-station-tests/src/tests/cli/token.rs
@@ -77,7 +77,7 @@ pub fn add_generated_token_to_db() -> Result<(), Box<dyn Error>> {
 
 #[test]
 pub fn add_generated_token_to_db_negative() -> Result<(), Box<dyn Error>> {
-    let temp_dir = TempDir::new().unwrap().into_persistent();
+    let temp_dir = TempDir::new().unwrap();
     let (server, _snapshot) = quick_start(&temp_dir).unwrap();
 
     let vit_cli: VitCli = Default::default();

--- a/vit-servicing-station-tests/src/tests/rest/advisor_reviews.rs
+++ b/vit-servicing-station-tests/src/tests/rest/advisor_reviews.rs
@@ -12,7 +12,7 @@ use vit_servicing_station_lib::db::models::community_advisors_reviews::{
 #[test]
 pub fn get_advisor_reviews() -> Result<(), Box<dyn std::error::Error>> {
     use pretty_assertions::assert_eq;
-    let temp_dir = TempDir::new().unwrap().into_persistent();
+    let temp_dir = TempDir::new().unwrap();
     let proposal_id = 1234;
     let expected_review = AdvisorReview {
         id: 1,

--- a/vit-servicing-station-tests/src/tests/rest/cors.rs
+++ b/vit-servicing-station-tests/src/tests/rest/cors.rs
@@ -130,7 +130,7 @@ pub fn cors_https() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 pub fn cors_multi_domain() -> Result<(), Box<dyn std::error::Error>> {
-    let temp_dir = TempDir::new().unwrap().into_persistent();
+    let temp_dir = TempDir::new().unwrap();
     let snapshot = ArbitrarySnapshotGenerator::default().snapshot();
     let db_path = DbBuilder::new().with_snapshot(&snapshot).build(&temp_dir)?;
 

--- a/vit-servicing-station-tests/src/tests/rest/funds.rs
+++ b/vit-servicing-station-tests/src/tests/rest/funds.rs
@@ -20,7 +20,7 @@ pub fn get_funds_list_is_not_empty() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 pub fn get_funds_by_id() -> Result<(), Box<dyn std::error::Error>> {
     use pretty_assertions::assert_eq;
-    let temp_dir = TempDir::new().unwrap().into_persistent();
+    let temp_dir = TempDir::new().unwrap();
     let mut expected_fund = data::funds().first().unwrap().clone();
     let (hash, token) = data::token();
 

--- a/vit-servicing-station-tests/src/tests/rest/proposals.rs
+++ b/vit-servicing-station-tests/src/tests/rest/proposals.rs
@@ -29,7 +29,7 @@ pub fn get_proposals_list_is_not_empty() {
 
 #[test]
 pub fn get_proposal_by_id() -> Result<(), Box<dyn std::error::Error>> {
-    let temp_dir = TempDir::new().unwrap().into_persistent();
+    let temp_dir = TempDir::new().unwrap();
 
     let mut gen = data::ArbitrarySnapshotGenerator::default();
 

--- a/vit-servicing-station-tests/src/tests/rest/voteplan_id.rs
+++ b/vit-servicing-station-tests/src/tests/rest/voteplan_id.rs
@@ -5,7 +5,7 @@ use vit_servicing_station_lib::v0::endpoints::proposals::ProposalVoteplanIdAndIn
 
 #[test]
 pub fn get_proposals_by_voteplan_id_and_index() {
-    let temp_dir = TempDir::new().unwrap().into_persistent();
+    let temp_dir = TempDir::new().unwrap();
     let snapshot = multivoteplan_snapshot();
 
     let db_path = DbBuilder::new()


### PR DESCRIPTION
in an attempt to reduce inter-dependency between tests/run-to-run nondeterminism, removes all calls to `into_persistent()` on temp dirs