### PR TITLE
Update search api, add pagination functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ name = "chain-vote"
 version = "0.1.0"
 source = "git+https://github.com/input-output-hk/chain-libs.git?branch=master#ef798477aba3794c7b4b171f0926884bc0327563"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "chain-core",
  "chain-crypto",
  "const_format",
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "047bfc4d5c3bd2ef6ca6f981941046113524b9a9f9a7cbdfdd7ff40f58e6f542"
+checksum = "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d"
 dependencies = [
  "byteorder",
  "diesel_derives",

--- a/doc/api/v0.yaml
+++ b/doc/api/v0.yaml
@@ -245,6 +245,25 @@ paths:
         "400":
           description: Invalid combination of table/column (e.g. using funds column on challenges table)
 
+  /api/v0/search_count:
+    post:
+      summary: Search various resources with various constraints and returns count of the result set
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SearchCountQuery"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: integer
+                format: i32
+                description: Count of the result set
+        "400":
+          description: Invalid combination of table/column (e.g. using funds column on challenges table)
 
   /api/v0/snapshot/{tag}/{voting_key}:
     get:
@@ -762,7 +781,30 @@ components:
           items:
               type: integer
               format: i64
+
     SearchQuery:
+      properties:
+        table:
+          $ref: "#/components/schemas/SearchConstraint"
+        filter:
+          type: array
+          items: 
+            $ref: "#/components/schemas/SearchConstraint"
+        order-by:
+          type: array
+          items: 
+            $ref: "#/components/schemas/SearchOrderBy"
+        limit:
+          type: integer
+          format: i32
+          description: Sets the limit clause of the search query.
+        offset:
+          type: integer
+          format: i32
+          description: Sets the offset clause of the search query.
+      required: [table]
+
+    SearchCountQuery:
       properties:
         table:
           $ref: "#/components/schemas/SearchConstraint"
@@ -776,7 +818,6 @@ components:
             $ref: "#/components/schemas/SearchOrderBy"
       required: [table]
 
-    
     SearchConstraint:
       properties:
         column:

--- a/vit-servicing-station-lib/src/db/queries/search/mod.rs
+++ b/vit-servicing-station-lib/src/db/queries/search/mod.rs
@@ -7,7 +7,9 @@ use diesel::{
 use crate::{
     db::{DbConnection, DbConnectionPool},
     v0::{
-        endpoints::search::requests::{Column, Constraint, OrderBy, Query, SearchResponse, Table},
+        endpoints::search::requests::{
+            Column, Constraint, OrderBy, Query, QueryCount, SearchResponse, Table,
+        },
         errors::HandleError,
     },
 };
@@ -18,6 +20,16 @@ pub async fn search_db(
 ) -> Result<SearchResponse, HandleError> {
     let db_conn = pool.get().map_err(HandleError::DatabaseError)?;
     tokio::task::spawn_blocking(move || search(query, &db_conn))
+        .await
+        .map_err(|_e| HandleError::InternalError("Error executing request".to_string()))?
+}
+
+pub async fn search_count_db(
+    query: QueryCount,
+    pool: &DbConnectionPool,
+) -> Result<i64, HandleError> {
+    let db_conn = pool.get().map_err(HandleError::DatabaseError)?;
+    tokio::task::spawn_blocking(move || search_count(query, &db_conn))
         .await
         .map_err(|_e| HandleError::InternalError("Error executing request".to_string()))?
 }
@@ -117,6 +129,89 @@ fn search(
                 .load(conn)
                 .map_err(|_| HandleError::InternalError("error searching".to_string()))?;
             Ok(SearchResponse::Proposal(vec))
+        }
+    }
+}
+
+fn search_count(
+    QueryCount {
+        table,
+        filter,
+        order_by,
+    }: QueryCount,
+    conn: &PooledConnection<ConnectionManager<DbConnection>>,
+) -> Result<i64, HandleError> {
+    match table {
+        Table::Challenges => {
+            use crate::db::schema::challenges::dsl::*;
+            use Column::*;
+
+            let mut query = challenges.into_boxed();
+
+            for Constraint { search, column } in filter {
+                let search = format!("%{search}%");
+                query = match column {
+                    Title => query.filter(title.like(search)),
+                    Desc => query.filter(description.like(search)),
+                    Type => query.filter(challenge_type.like(search)),
+                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
+                }
+            }
+
+            for OrderBy { column, descending } in order_by {
+                query = match (descending, column) {
+                    (false, Title) => query.then_order_by(title),
+                    (false, Desc) => query.then_order_by(description),
+                    (false, Type) => query.then_order_by(challenge_type),
+                    (true, Title) => query.then_order_by(title.desc()),
+                    (true, Desc) => query.then_order_by(description.desc()),
+                    (true, Type) => query.then_order_by(challenge_type.desc()),
+                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
+                }
+            }
+
+            let count = query
+                .count()
+                .get_result(conn)
+                .map_err(|_| HandleError::InternalError("error searching".to_string()))?;
+            Ok(count)
+        }
+        Table::Proposals => {
+            use crate::db::views_schema::full_proposals_info::dsl::*;
+            use full_proposals_info as proposals;
+            use Column::*;
+
+            let mut query = proposals.into_boxed();
+
+            for Constraint { search, column } in filter {
+                let search = format!("%{search}%");
+                query = match column {
+                    Title => query.filter(proposal_title.like(search)),
+                    Desc => query.filter(proposal_summary.like(search)),
+                    Author => query.filter(proposer_name.like(search)),
+                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
+                }
+            }
+
+            for OrderBy { column, descending } in order_by {
+                query = match (descending, column) {
+                    (false, Title) => query.then_order_by(proposal_title),
+                    (false, Desc) => query.then_order_by(proposal_summary),
+                    (false, Author) => query.then_order_by(proposer_name),
+                    (false, Funds) => query.then_order_by(proposal_funds),
+                    (true, Title) => query.then_order_by(proposal_title.desc()),
+                    (true, Desc) => query.then_order_by(proposal_summary.desc()),
+                    (true, Author) => query.then_order_by(proposer_name.desc()),
+                    (true, Funds) => query.then_order_by(proposal_funds.desc()),
+                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
+                }
+            }
+
+            let count = query
+                .count()
+                .get_result(conn)
+                .map_err(|_| HandleError::InternalError("error searching".to_string()))?;
+            Ok(count)
         }
     }
 }

--- a/vit-servicing-station-lib/src/db/queries/search/mod.rs
+++ b/vit-servicing-station-lib/src/db/queries/search/mod.rs
@@ -1,17 +1,17 @@
-use diesel::{
-    expression_methods::ExpressionMethods,
-    r2d2::{ConnectionManager, PooledConnection},
-    QueryDsl, RunQueryDsl, TextExpressionMethods,
-};
-
 use crate::{
-    db::{DbConnection, DbConnectionPool},
+    db::{schema, DbConnection, DbConnectionPool},
     v0::{
         endpoints::search::requests::{
             Column, Constraint, OrderBy, SearchCountQuery, SearchQuery, SearchResponse, Table,
         },
         errors::HandleError,
     },
+};
+use diesel::{
+    backend::Backend,
+    expression_methods::ExpressionMethods,
+    r2d2::{ConnectionManager, PooledConnection},
+    QueryDsl, RunQueryDsl, TextExpressionMethods,
 };
 
 pub async fn search_db(
@@ -34,6 +34,140 @@ pub async fn search_count_db(
         .map_err(|_e| HandleError::InternalError("Error executing request".to_string()))?
 }
 
+type ChallengesSelectST = (
+    diesel::sql_types::Integer,
+    diesel::sql_types::Integer,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::BigInt,
+    diesel::sql_types::BigInt,
+    diesel::sql_types::Integer,
+    diesel::sql_types::Text,
+    diesel::sql_types::Nullable<diesel::sql_types::Text>,
+);
+
+fn build_challenges_query<'a, DB: 'a + Backend>(
+    filter: Vec<Constraint>,
+    order_by: Vec<OrderBy>,
+) -> Result<
+    diesel::query_builder::BoxedSelectStatement<
+        'a,
+        ChallengesSelectST,
+        schema::challenges::table,
+        DB,
+    >,
+    HandleError,
+> {
+    use crate::db::schema::challenges::dsl::*;
+    use Column::*;
+
+    let mut query = challenges.into_boxed();
+
+    for Constraint { search, column } in filter {
+        let search = format!("%{search}%");
+        query = match column {
+            Title => query.filter(title.like(search)),
+            Desc => query.filter(description.like(search)),
+            Type => query.filter(challenge_type.like(search)),
+            _ => return Err(HandleError::BadRequest("invalid column".to_string())),
+        }
+    }
+
+    for OrderBy { column, descending } in order_by {
+        query = match (descending, column) {
+            (false, Title) => query.then_order_by(title),
+            (false, Desc) => query.then_order_by(description),
+            (false, Type) => query.then_order_by(challenge_type),
+            (true, Title) => query.then_order_by(title.desc()),
+            (true, Desc) => query.then_order_by(description.desc()),
+            (true, Type) => query.then_order_by(challenge_type.desc()),
+            _ => return Err(HandleError::BadRequest("invalid column".to_string())),
+        }
+    }
+    Ok(query)
+}
+
+type SelectProposalsST = (
+    diesel::sql_types::Integer,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::BigInt,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::BigInt,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::Binary,
+    diesel::sql_types::Text,
+    diesel::sql_types::Integer,
+    diesel::sql_types::Integer,
+    diesel::sql_types::BigInt,
+    diesel::sql_types::BigInt,
+    diesel::sql_types::BigInt,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+    diesel::sql_types::Integer,
+    diesel::sql_types::Text,
+    diesel::sql_types::Nullable<diesel::sql_types::Text>,
+    diesel::sql_types::Nullable<diesel::sql_types::Text>,
+    diesel::sql_types::Nullable<diesel::sql_types::Text>,
+    diesel::sql_types::Nullable<diesel::sql_types::Text>,
+    diesel::sql_types::Nullable<diesel::sql_types::Text>,
+    diesel::sql_types::BigInt,
+    diesel::sql_types::Text,
+    diesel::sql_types::Text,
+);
+
+fn build_proposals_query<'a, DB: 'a + Backend>(
+    filter: Vec<Constraint>,
+    order_by: Vec<OrderBy>,
+) -> Result<
+    diesel::query_builder::BoxedSelectStatement<
+        'a,
+        SelectProposalsST,
+        crate::db::views_schema::full_proposals_info::table,
+        DB,
+    >,
+    HandleError,
+> {
+    use crate::db::views_schema::full_proposals_info::dsl::*;
+    use full_proposals_info as proposals;
+    use Column::*;
+
+    let mut query = proposals.into_boxed();
+
+    for Constraint { search, column } in filter {
+        let search = format!("%{search}%");
+        query = match column {
+            Title => query.filter(proposal_title.like(search)),
+            Desc => query.filter(proposal_summary.like(search)),
+            Author => query.filter(proposer_name.like(search)),
+            _ => return Err(HandleError::BadRequest("invalid column".to_string())),
+        }
+    }
+
+    for OrderBy { column, descending } in order_by {
+        query = match (descending, column) {
+            (false, Title) => query.then_order_by(proposal_title),
+            (false, Desc) => query.then_order_by(proposal_summary),
+            (false, Author) => query.then_order_by(proposer_name),
+            (false, Funds) => query.then_order_by(proposal_funds),
+            (true, Title) => query.then_order_by(proposal_title.desc()),
+            (true, Desc) => query.then_order_by(proposal_summary.desc()),
+            (true, Author) => query.then_order_by(proposer_name.desc()),
+            (true, Funds) => query.then_order_by(proposal_funds.desc()),
+            _ => return Err(HandleError::BadRequest("invalid column".to_string())),
+        }
+    }
+    Ok(query)
+}
+
 fn search(
     SearchQuery {
         query,
@@ -50,32 +184,7 @@ fn search(
 
     match table {
         Table::Challenges => {
-            use crate::db::schema::challenges::dsl::*;
-            use Column::*;
-
-            let mut query = challenges.into_boxed();
-
-            for Constraint { search, column } in filter {
-                let search = format!("%{search}%");
-                query = match column {
-                    Title => query.filter(title.like(search)),
-                    Desc => query.filter(description.like(search)),
-                    Type => query.filter(challenge_type.like(search)),
-                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
-                }
-            }
-
-            for OrderBy { column, descending } in order_by {
-                query = match (descending, column) {
-                    (false, Title) => query.then_order_by(title),
-                    (false, Desc) => query.then_order_by(description),
-                    (false, Type) => query.then_order_by(challenge_type),
-                    (true, Title) => query.then_order_by(title.desc()),
-                    (true, Desc) => query.then_order_by(description.desc()),
-                    (true, Type) => query.then_order_by(challenge_type.desc()),
-                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
-                }
-            }
+            let mut query = build_challenges_query(filter, order_by)?;
 
             if let Some(limit) = limit {
                 query = query.limit(limit)
@@ -91,35 +200,7 @@ fn search(
             Ok(SearchResponse::Challenge(vec))
         }
         Table::Proposals => {
-            use crate::db::views_schema::full_proposals_info::dsl::*;
-            use full_proposals_info as proposals;
-            use Column::*;
-
-            let mut query = proposals.into_boxed();
-
-            for Constraint { search, column } in filter {
-                let search = format!("%{search}%");
-                query = match column {
-                    Title => query.filter(proposal_title.like(search)),
-                    Desc => query.filter(proposal_summary.like(search)),
-                    Author => query.filter(proposer_name.like(search)),
-                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
-                }
-            }
-
-            for OrderBy { column, descending } in order_by {
-                query = match (descending, column) {
-                    (false, Title) => query.then_order_by(proposal_title),
-                    (false, Desc) => query.then_order_by(proposal_summary),
-                    (false, Author) => query.then_order_by(proposer_name),
-                    (false, Funds) => query.then_order_by(proposal_funds),
-                    (true, Title) => query.then_order_by(proposal_title.desc()),
-                    (true, Desc) => query.then_order_by(proposal_summary.desc()),
-                    (true, Author) => query.then_order_by(proposer_name.desc()),
-                    (true, Funds) => query.then_order_by(proposal_funds.desc()),
-                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
-                }
-            }
+            let mut query = build_proposals_query(filter, order_by)?;
 
             if let Some(limit) = limit {
                 query = query.limit(limit)
@@ -147,32 +228,7 @@ fn search_count(
 ) -> Result<i64, HandleError> {
     match table {
         Table::Challenges => {
-            use crate::db::schema::challenges::dsl::*;
-            use Column::*;
-
-            let mut query = challenges.into_boxed();
-
-            for Constraint { search, column } in filter {
-                let search = format!("%{search}%");
-                query = match column {
-                    Title => query.filter(title.like(search)),
-                    Desc => query.filter(description.like(search)),
-                    Type => query.filter(challenge_type.like(search)),
-                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
-                }
-            }
-
-            for OrderBy { column, descending } in order_by {
-                query = match (descending, column) {
-                    (false, Title) => query.then_order_by(title),
-                    (false, Desc) => query.then_order_by(description),
-                    (false, Type) => query.then_order_by(challenge_type),
-                    (true, Title) => query.then_order_by(title.desc()),
-                    (true, Desc) => query.then_order_by(description.desc()),
-                    (true, Type) => query.then_order_by(challenge_type.desc()),
-                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
-                }
-            }
+            let query = build_challenges_query(filter, order_by)?;
 
             let count = query
                 .count()
@@ -181,35 +237,7 @@ fn search_count(
             Ok(count)
         }
         Table::Proposals => {
-            use crate::db::views_schema::full_proposals_info::dsl::*;
-            use full_proposals_info as proposals;
-            use Column::*;
-
-            let mut query = proposals.into_boxed();
-
-            for Constraint { search, column } in filter {
-                let search = format!("%{search}%");
-                query = match column {
-                    Title => query.filter(proposal_title.like(search)),
-                    Desc => query.filter(proposal_summary.like(search)),
-                    Author => query.filter(proposer_name.like(search)),
-                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
-                }
-            }
-
-            for OrderBy { column, descending } in order_by {
-                query = match (descending, column) {
-                    (false, Title) => query.then_order_by(proposal_title),
-                    (false, Desc) => query.then_order_by(proposal_summary),
-                    (false, Author) => query.then_order_by(proposer_name),
-                    (false, Funds) => query.then_order_by(proposal_funds),
-                    (true, Title) => query.then_order_by(proposal_title.desc()),
-                    (true, Desc) => query.then_order_by(proposal_summary.desc()),
-                    (true, Author) => query.then_order_by(proposer_name.desc()),
-                    (true, Funds) => query.then_order_by(proposal_funds.desc()),
-                    _ => return Err(HandleError::BadRequest("invalid column".to_string())),
-                }
-            }
+            let query = build_proposals_query(filter, order_by)?;
 
             let count = query
                 .count()

--- a/vit-servicing-station-lib/src/db/queries/search/mod.rs
+++ b/vit-servicing-station-lib/src/db/queries/search/mod.rs
@@ -27,6 +27,8 @@ fn search(
         table,
         filter,
         order_by,
+        limit,
+        offset,
     }: Query,
     conn: &PooledConnection<ConnectionManager<DbConnection>>,
 ) -> Result<SearchResponse, HandleError> {
@@ -57,6 +59,14 @@ fn search(
                     (true, Type) => query.then_order_by(challenge_type.desc()),
                     _ => return Err(HandleError::BadRequest("invalid column".to_string())),
                 }
+            }
+
+            if let Some(limit) = limit {
+                query = query.limit(limit)
+            }
+
+            if let Some(offset) = offset {
+                query = query.offset(offset)
             }
 
             let vec = query
@@ -93,6 +103,14 @@ fn search(
                     (true, Funds) => query.then_order_by(proposal_funds.desc()),
                     _ => return Err(HandleError::BadRequest("invalid column".to_string())),
                 }
+            }
+
+            if let Some(limit) = limit {
+                query = query.limit(limit)
+            }
+
+            if let Some(offset) = offset {
+                query = query.offset(offset)
             }
 
             let vec = query

--- a/vit-servicing-station-lib/src/v0/endpoints/mod.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/mod.rs
@@ -51,8 +51,10 @@ pub async fn filter(
 
     let search_root = warp::path!("search" / ..);
     let search_filter = search::search_filter(search_root.boxed(), context.clone()).await;
+
+    let search_count_root = warp::path!("search_count" / ..);
     let search_count_filter =
-        search::search_count_filter(search_root.boxed(), context.clone()).await;
+        search::search_count_filter(search_count_root.boxed(), context.clone()).await;
 
     let snapshot_root = warp::path!("snapshot" / ..);
     let snapshot_rx_filter = snapshot_service::filter(snapshot_root.boxed(), snapshot_rx.clone());

--- a/vit-servicing-station-lib/src/v0/endpoints/mod.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/mod.rs
@@ -50,7 +50,9 @@ pub async fn filter(
     let reviews_filter = advisor_reviews::filter(reviews_root.boxed(), context.clone()).await;
 
     let search_root = warp::path!("search" / ..);
-    let search_filter = search::filter(search_root.boxed(), context.clone()).await;
+    let search_filter = search::search_filter(search_root.boxed(), context.clone()).await;
+    let search_count_filter =
+        search::search_count_filter(search_root.boxed(), context.clone()).await;
 
     let snapshot_root = warp::path!("snapshot" / ..);
     let snapshot_rx_filter = snapshot_service::filter(snapshot_root.boxed(), snapshot_rx.clone());
@@ -82,6 +84,7 @@ pub async fn filter(
                 .or(challenges_filter)
                 .or(reviews_filter)
                 .or(search_filter)
+                .or(search_count_filter)
                 .or(snapshot_rx_filter)
                 .or(admin_filter),
         ),

--- a/vit-servicing-station-lib/src/v0/endpoints/search/mod.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/search/mod.rs
@@ -2,4 +2,5 @@ mod logic;
 pub mod requests;
 mod routes;
 
-pub use routes::filter;
+pub use routes::search_count_filter;
+pub use routes::search_filter;

--- a/vit-servicing-station-lib/src/v0/endpoints/search/requests.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/search/requests.rs
@@ -16,6 +16,16 @@ pub struct Query {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
+pub struct QueryCount {
+    pub table: Table,
+    #[serde(default)]
+    pub filter: Vec<Constraint>,
+    #[serde(default)]
+    pub order_by: Vec<OrderBy>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Constraint {
     pub search: String,
     pub column: Column,
@@ -72,5 +82,6 @@ mod tests {
     #[test]
     fn filters_and_orders_are_optional() {
         from_value::<Query>(json!({"table": "proposals"})).unwrap();
+        from_value::<QueryCount>(json!({"table": "proposals"})).unwrap();
     }
 }

--- a/vit-servicing-station-lib/src/v0/endpoints/search/requests.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/search/requests.rs
@@ -10,6 +10,8 @@ pub struct Query {
     pub filter: Vec<Constraint>,
     #[serde(default)]
     pub order_by: Vec<OrderBy>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/vit-servicing-station-lib/src/v0/endpoints/search/requests.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/search/requests.rs
@@ -4,19 +4,16 @@ use crate::db::models::{challenges::Challenge, proposals::FullProposalInfo};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub struct Query {
-    pub table: Table,
-    #[serde(default)]
-    pub filter: Vec<Constraint>,
-    #[serde(default)]
-    pub order_by: Vec<OrderBy>,
+pub struct SearchQuery {
+    #[serde(flatten)]
+    pub query: SearchCountQuery,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub struct QueryCount {
+pub struct SearchCountQuery {
     pub table: Table,
     #[serde(default)]
     pub filter: Vec<Constraint>,
@@ -81,7 +78,7 @@ mod tests {
 
     #[test]
     fn filters_and_orders_are_optional() {
-        from_value::<Query>(json!({"table": "proposals"})).unwrap();
-        from_value::<QueryCount>(json!({"table": "proposals"})).unwrap();
+        from_value::<SearchQuery>(json!({"table": "proposals"})).unwrap();
+        from_value::<SearchCountQuery>(json!({"table": "proposals"})).unwrap();
     }
 }

--- a/vit-servicing-station-lib/src/v0/endpoints/search/routes.rs
+++ b/vit-servicing-station-lib/src/v0/endpoints/search/routes.rs
@@ -4,7 +4,7 @@ use crate::v0::context::SharedContext;
 
 use super::logic;
 
-pub async fn filter(
+pub async fn search_filter(
     root: BoxedFilter<()>,
     context: SharedContext,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
@@ -13,5 +13,17 @@ pub async fn filter(
             .and(warp::body::json())
             .and(warp::any().map(move || context.clone()))
             .and_then(logic::search),
+    )
+}
+
+pub async fn search_count_filter(
+    root: BoxedFilter<()>,
+    context: SharedContext,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    root.and(
+        warp::post()
+            .and(warp::body::json())
+            .and(warp::any().map(move || context.clone()))
+            .and_then(logic::search_count),
     )
 }


### PR DESCRIPTION
-  modify `/api/v0/search` request type, extended it with the new optional fields `limit` and `offset`, which can be used to limit the query result and provide an offset of the resulted data
```
    SearchQuery:
      properties:
        table:
          $ref: "#/components/schemas/SearchConstraint"
        filter:
          type: array
          items: 
            $ref: "#/components/schemas/SearchConstraint"
        order-by:
          type: array
          items: 
            $ref: "#/components/schemas/SearchOrderBy"
        limit:
          type: integer
          format: i32
          description: Sets the limit clause of the search query.
        offset:
          type: integer
          format: i32
          description: Sets the offset clause of the search query.
      required: [table]
```
- added new endpoint `/api/v0/search_count` which returns a count of the query results. Response type is the oldest response type for `/api/v0/search`. Actually it is quite the same if you will execute `/api/v0/search().len()`, but does it in more performance way.
```
    SearchCountQuery:
      properties:
        table:
          $ref: "#/components/schemas/SearchConstraint"
        filter:
          type: array
          items: 
            $ref: "#/components/schemas/SearchConstraint"
        order-by:
          type: array
          items: 
            $ref: "#/components/schemas/SearchOrderBy"
      required: [table]
```
